### PR TITLE
Solves an issue where two or more timers where running at the same time

### DIFF
--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -465,6 +465,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       _timer = Timer.periodic(
         const Duration(milliseconds: 300),
         (Timer timer) async {
+          if (timer != _timer) {
+            timer.cancel();
+            return;
+          }
           if (_isDisposed) {
             return;
           }


### PR DESCRIPTION
## Problem
The library has several uses of the better player and video player play functions without an await. There are several cases where the play function is called in burst (2-3 times) and this originates two or more internal timers in the player. Which creates bugs when the video is over.

## Solution
Cancel any timers (inside the timer idle) that are not the one inside the class. Cancels any additional timers and only keeps one timer alive at a time.

# Video (Before/After)
## Before
https://user-images.githubusercontent.com/1333232/224280180-4ac70efc-4671-4b20-8005-3487d74ece48.mp4

## After
https://user-images.githubusercontent.com/1333232/224282920-8280e21c-2a60-4546-97ba-b0cf5aafc458.mp4