### PR TITLE
Feature/daf 3918 add method channel for auto pip transition

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -189,6 +189,10 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 )
                 result.success(null)
             }
+            SETUP_TO_START_PICTURE_IN_PICTURE_AUTOMATICALLY -> {
+                val willStartPIPPIP = call.argument<Boolean?>(WILL_START_PIP)
+                setupToStartPictureInPictureAutomatically(willStartPIPPIP ?: false)
+            }
             ENABLE_PICTURE_IN_PICTURE_METHOD -> {
                 enablePictureInPicture(player)
                 result.success(null)
@@ -406,6 +410,11 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             .hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
     }
 
+    private fun setupToStartPictureInPictureAutomatically(willStartPIP: Boolean) {
+        println("setupToStartPictureInPictureAutomatically willStartPIP: ${willStartPIP.toString()}")
+        // TODO: Implement
+    }
+
     private fun enablePictureInPicture(player: BetterPlayer) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             player.setupMediaSession(flutterState!!.applicationContext)
@@ -512,6 +521,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val DRM_HEADERS_PARAMETER = "drmHeaders"
         private const val DRM_CLEARKEY_PARAMETER = "clearKey"
         private const val MIX_WITH_OTHERS_PARAMETER = "mixWithOthers"
+        private const val WILL_START_PIP = "willStartPIP"
         const val URL_PARAMETER = "url"
         const val PRE_CACHE_SIZE_PARAMETER = "preCacheSize"
         const val MAX_CACHE_SIZE_PARAMETER = "maxCacheSize"
@@ -537,6 +547,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val SET_SPEED_METHOD = "setSpeed"
         private const val SET_TRACK_PARAMETERS_METHOD = "setTrackParameters"
         private const val SET_AUDIO_TRACK_METHOD = "setAudioTrack"
+        private const val SETUP_TO_START_PICTURE_IN_PICTURE_AUTOMATICALLY = "setupToStartPictureInPictureAutomatically"
         private const val ENABLE_PICTURE_IN_PICTURE_METHOD = "enablePictureInPicture"
         private const val DISABLE_PICTURE_IN_PICTURE_METHOD = "disablePictureInPicture"
         private const val IS_PICTURE_IN_PICTURE_SUPPORTED_METHOD = "isPictureInPictureSupported"

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -190,8 +190,8 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 result.success(null)
             }
             SETUP_AUTOMATIC_PICTURE_IN_PICTURE_TRANSITION -> {
-                val willStartPIPPIP = call.argument<Boolean?>(WILL_START_PIP)
-                setupAutomaticPictureInPictureTransition(willStartPIPPIP ?: false)
+                val willStartPIP = call.argument<Boolean?>(WILL_START_PIP)!!
+                setupAutomaticPictureInPictureTransition(willStartPIP)
             }
             ENABLE_PICTURE_IN_PICTURE_METHOD -> {
                 enablePictureInPicture(player)

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -189,9 +189,9 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 )
                 result.success(null)
             }
-            SETUP_TO_START_PICTURE_IN_PICTURE_AUTOMATICALLY -> {
+            SETUP_AUTOMATIC_PICTURE_IN_PICTURE_TRANSITION -> {
                 val willStartPIPPIP = call.argument<Boolean?>(WILL_START_PIP)
-                setupToStartPictureInPictureAutomatically(willStartPIPPIP ?: false)
+                setupAutomaticPictureInPictureTransition(willStartPIPPIP ?: false)
             }
             ENABLE_PICTURE_IN_PICTURE_METHOD -> {
                 enablePictureInPicture(player)
@@ -410,8 +410,8 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             .hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
     }
 
-    private fun setupToStartPictureInPictureAutomatically(willStartPIP: Boolean) {
-        println("setupToStartPictureInPictureAutomatically willStartPIP: ${willStartPIP.toString()}")
+    private fun setupAutomaticPictureInPictureTransition(willStartPIP: Boolean) {
+        println("setupAutomaticPictureInPictureTransition willStartPIP: ${willStartPIP.toString()}")
         // TODO: Implement
     }
 
@@ -547,7 +547,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val SET_SPEED_METHOD = "setSpeed"
         private const val SET_TRACK_PARAMETERS_METHOD = "setTrackParameters"
         private const val SET_AUDIO_TRACK_METHOD = "setAudioTrack"
-        private const val SETUP_TO_START_PICTURE_IN_PICTURE_AUTOMATICALLY = "setupToStartPictureInPictureAutomatically"
+        private const val SETUP_AUTOMATIC_PICTURE_IN_PICTURE_TRANSITION = "setupAutomaticPictureInPictureTransition"
         private const val ENABLE_PICTURE_IN_PICTURE_METHOD = "enablePictureInPicture"
         private const val DISABLE_PICTURE_IN_PICTURE_METHOD = "disablePictureInPicture"
         private const val IS_PICTURE_IN_PICTURE_SUPPORTED_METHOD = "isPictureInPictureSupported"

--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -46,6 +46,12 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
   }
 
   @override
+  void dispose() {
+    _betterPlayerController.removeEventsListener(_betterPlayerListener);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -9,6 +9,7 @@ class PictureInPicturePage extends StatefulWidget {
 
 class _PictureInPicturePageState extends State<PictureInPicturePage> {
   late BetterPlayerController _betterPlayerController;
+  late Function(BetterPlayerEvent) _betterPlayerListener;
   GlobalKey _betterPlayerKey = GlobalKey();
 
   @override
@@ -25,6 +26,22 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
     _betterPlayerController = BetterPlayerController(betterPlayerConfiguration);
     _betterPlayerController.setupDataSource(dataSource);
     _betterPlayerController.setBetterPlayerGlobalKey(_betterPlayerKey);
+
+    _betterPlayerListener = (event) async {
+      if (!mounted) {
+        return;
+      }
+
+      if (event.betterPlayerEventType == BetterPlayerEventType.play) {
+        _betterPlayerController.setupToStartPictureInPictureAutomatically(
+            willStartPIP: true);
+      } else if (event.betterPlayerEventType == BetterPlayerEventType.pause) {
+        _betterPlayerController.setupToStartPictureInPictureAutomatically(
+            willStartPIP: false);
+      }
+    };
+
+    _betterPlayerController.addEventsListener(_betterPlayerListener);
     super.initState();
   }
 

--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -33,10 +33,10 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
       }
 
       if (event.betterPlayerEventType == BetterPlayerEventType.play) {
-        _betterPlayerController.setupToStartPictureInPictureAutomatically(
+        _betterPlayerController.setupAutomaticPictureInPictureTransition(
             willStartPIP: true);
       } else if (event.betterPlayerEventType == BetterPlayerEventType.pause) {
-        _betterPlayerController.setupToStartPictureInPictureAutomatically(
+        _betterPlayerController.setupAutomaticPictureInPictureTransition(
             willStartPIP: false);
       }
     };

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -398,6 +398,9 @@ bool _remoteCommandsInitialized = false;
 
             [player setTrackParameters:width: height : bitrate];
             result(nil);
+        } else if ([@"setupAutomaticPictureInPictureTransition" isEqualToString:call.method]){
+            // TODO: Implement
+            NSLog(@"setupAutomaticPictureInPictureTransition willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
         } else if ([@"enablePictureInPicture" isEqualToString:call.method]){
             double left = [argsMap[@"left"] doubleValue];
             double top = [argsMap[@"top"] doubleValue];
@@ -466,9 +469,6 @@ bool _remoteCommandsInitialized = false;
                 }
             }
             result(nil);
-        } else if ([@"setupAutomaticPictureInPictureTransition" isEqualToString:call.method]){
-            // TODO: Implement
-            NSLog(@"setupAutomaticPictureInPictureTransition willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
         } else {
             result(FlutterMethodNotImplemented);
         }

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -466,9 +466,9 @@ bool _remoteCommandsInitialized = false;
                 }
             }
             result(nil);
-        } else if ([@"setupToStartPictureInPictureAutomatically" isEqualToString:call.method]){
+        } else if ([@"setupAutomaticPictureInPictureTransition" isEqualToString:call.method]){
             // TODO: Implement
-            NSLog(@"setupToStartPictureInPictureAutomatically willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
+            NSLog(@"setupAutomaticPictureInPictureTransition willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
         } else {
             result(FlutterMethodNotImplemented);
         }

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -466,6 +466,9 @@ bool _remoteCommandsInitialized = false;
                 }
             }
             result(nil);
+        } else if ([@"setupToStartPictureInPictureAutomatically" isEqualToString:call.method]){
+            // TODO: Implement
+            NSLog(@"setupToStartPictureInPictureAutomatically willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
         } else {
             result(FlutterMethodNotImplemented);
         }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1054,7 +1054,7 @@ class BetterPlayerController {
 
   ///Set up to start Picture in Picture automatically when close app.
   ///When device is not supported, PiP mode won't be open.
-  Future<void>? setupToStartPictureInPictureAutomatically(
+  Future<void>? setupAutomaticPictureInPictureTransition(
       {required bool willStartPIP}) async {
     if (videoPlayerController == null) {
       throw StateError("The data source has not been initialized");
@@ -1064,7 +1064,7 @@ class BetterPlayerController {
         (await videoPlayerController?.isPictureInPictureSupported()) ?? false;
 
     if (isPipSupported) {
-      await videoPlayerController?.setupToStartPictureInPictureAutomatically(
+      await videoPlayerController?.setupAutomaticPictureInPictureTransition(
         willStartPIP: willStartPIP,
       );
     } else {

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1052,6 +1052,29 @@ class BetterPlayerController {
     return _overriddenFit ?? betterPlayerConfiguration.fit;
   }
 
+  ///Set up to start Picture in Picture automatically when close app.
+  ///When device is not supported, PiP mode won't be open.
+  Future<void>? setupToStartPictureInPictureAutomatically(
+      {required bool willStartPIP}) async {
+    if (videoPlayerController == null) {
+      throw StateError("The data source has not been initialized");
+    }
+
+    final bool isPipSupported =
+        (await videoPlayerController?.isPictureInPictureSupported()) ?? false;
+
+    if (isPipSupported) {
+      await videoPlayerController?.setupToStartPictureInPictureAutomatically(
+        willStartPIP: willStartPIP,
+      );
+    } else {
+      BetterPlayerUtils.log(
+          "Picture in picture is not supported in this device. If you're "
+          "using Android, please check if you're using activity v2 "
+          "embedding.");
+    }
+  }
+
   ///Enable Picture in Picture (PiP) mode. [betterPlayerGlobalKey] is required
   ///to open PiP mode in iOS. When device is not supported, PiP mode won't be
   ///open.

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -223,6 +223,20 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<void> setupToStartPictureInPictureAutomatically({
+    int? textureId,
+    bool? willStartPIP,
+  }) async {
+    return _channel.invokeMethod<void>(
+      'setupToStartPictureInPictureAutomatically',
+      <String, dynamic>{
+        'textureId': textureId,
+        'willStartPIP': willStartPIP,
+      },
+    );
+  }
+
+  @override
   Future<void> enablePictureInPicture(int? textureId, double? top, double? left,
       double? width, double? height) async {
     return _channel.invokeMethod<void>(

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -223,12 +223,12 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<void> setupToStartPictureInPictureAutomatically({
+  Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,
     bool? willStartPIP,
   }) async {
     return _channel.invokeMethod<void>(
-      'setupToStartPictureInPictureAutomatically',
+      'setupAutomaticPictureInPictureTransition',
       <String, dynamic>{
         'textureId': textureId,
         'willStartPIP': willStartPIP,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -593,6 +593,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         _textureId, width, height, bitrate);
   }
 
+  Future<void> setupToStartPictureInPictureAutomatically(
+      {bool? willStartPIP}) async {
+    await _videoPlayerPlatform.setupToStartPictureInPictureAutomatically(
+      textureId: textureId,
+      willStartPIP: willStartPIP,
+    );
+  }
+
   Future<void> enablePictureInPicture(
       {double? top, double? left, double? width, double? height}) async {
     await _videoPlayerPlatform.enablePictureInPicture(

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -593,9 +593,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         _textureId, width, height, bitrate);
   }
 
-  Future<void> setupToStartPictureInPictureAutomatically(
+  Future<void> setupAutomaticPictureInPictureTransition(
       {bool? willStartPIP}) async {
-    await _videoPlayerPlatform.setupToStartPictureInPictureAutomatically(
+    await _videoPlayerPlatform.setupAutomaticPictureInPictureTransition(
       textureId: textureId,
       willStartPIP: willStartPIP,
     );

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -137,6 +137,15 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('getAbsolutePosition() has not been implemented.');
   }
 
+  ///Set up auto PiP transition.
+  Future<void> setupToStartPictureInPictureAutomatically({
+    int? textureId,
+    bool? willStartPIP,
+  }) {
+    throw UnimplementedError(
+        'setupToStartPictureInPictureAutomatically() has not been implemented.');
+  }
+
   ///Enables PiP mode.
   Future<void> enablePictureInPicture(int? textureId, double? top, double? left,
       double? width, double? height) {

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -138,12 +138,12 @@ abstract class VideoPlayerPlatform {
   }
 
   ///Set up auto PiP transition.
-  Future<void> setupToStartPictureInPictureAutomatically({
+  Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,
     bool? willStartPIP,
   }) {
     throw UnimplementedError(
-        'setupToStartPictureInPictureAutomatically() has not been implemented.');
+        'setupAutomaticPictureInPictureTransition() has not been implemented.');
   }
 
   ///Enables PiP mode.


### PR DESCRIPTION
### Description 
Add method channel to setup automatic transition to Picture in Picture mode when app close.
This method will call when Start playing video if user authorized to watch the video

Ticket: 
https://dw-ml-nfc.atlassian.net/browse/DAF-3918

### Why need this PR?
There is `enablePictureInPicture` and `disablePictureInPicture` but actuary they are start/stop PIP immediately. No function to setup automatic transition.

NOTE: That PR is just adding a mehod cahnnel from flutter, process in each OS will be done next PR.