### PR TITLE
feature/DAF-3938

### DIFF
--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -18,6 +18,7 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
         BetterPlayerConfiguration(
       aspectRatio: 16 / 9,
       fit: BoxFit.contain,
+      handleLifecycle: false,
     );
     BetterPlayerDataSource dataSource = BetterPlayerDataSource(
       BetterPlayerDataSourceType.network,

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) NSString* key;
 @property(nonatomic, readonly) int failedCount;
 @property(nonatomic) AVPlayerLayer* _playerLayer;
+@property(nonatomic) BetterPlayerView* _betterPlayerView;
 @property(nonatomic) bool _pictureInPicture;
 @property(nonatomic) bool _observersAdded;
 @property(nonatomic) int stalledCount;
@@ -54,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) enablePictureInPicture: (CGRect) frame;
 - (void)setPictureInPicture:(BOOL)pictureInPicture;
 - (void)disablePictureInPicture;
+- (void)willStartPictureInPicture:(bool)willStart;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -667,7 +667,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)preparePictureInPicture: (CGRect) frame
 {
-    if( _player)
+    if(_player)
     {
         // Create new controller passing reference to the AVPlayerLayer
         self._playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -696,7 +696,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)disablePictureInPicture
 {
-    [self setPictureInPicture:true];
     if (__playerLayer){
         [self._playerLayer removeFromSuperlayer];
         self._playerLayer = nil;

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -399,8 +399,7 @@ bool _remoteCommandsInitialized = false;
             [player setTrackParameters:width: height : bitrate];
             result(nil);
         } else if ([@"setupAutomaticPictureInPictureTransition" isEqualToString:call.method]){
-            // TODO: Implement
-            NSLog(@"setupAutomaticPictureInPictureTransition willStartPIP: %d", [argsMap[@"willStartPIP"] boolValue]);
+            [player willStartPictureInPicture:[argsMap[@"willStartPIP"] boolValue]];
         } else if ([@"enablePictureInPicture" isEqualToString:call.method]){
             double left = [argsMap[@"left"] doubleValue];
             double top = [argsMap[@"top"] doubleValue];


### PR DESCRIPTION
## Description
Fixed to show PIP if the app is closed while playing a video.

### Problem
The process of automatic PIP when the application is closed is not implemented.

### Solution
code fix

### What was done (Please be a little bit specific)

- Fixed PIP to be ready for display when video playback starts
- Fixed to discard the state of PIP when playback is stopped.

tutorial link: https://developer.apple.com/documentation/avkit/adopting_picture_in_picture_in_a_custom_player?language=objc 

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-3938

## Screenshot or Video (Before/After)

https://user-images.githubusercontent.com/5037928/233959112-dfaacc29-ad60-4f05-9881-f32727e50c4a.MOV


