### PR TITLE
Feature/daf 3938

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -40,6 +40,9 @@ AVPictureInPictureController *_pipController;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
+    if (!_pipController) {
+        [self setupPipController];
+    }
     return playerView;
 }
 
@@ -802,6 +805,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)dispose {
+    _pipController = nil;
     [self pause];
     [self disposeSansEventChannel];
     [_eventChannel setStreamHandler:nil];

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -722,11 +722,15 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)pictureInPictureControllerWillStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
-
+    if (_eventSink != nil) {
+        _eventSink(@{@"event" : @"exitingPIP"});
+    }
 }
 
 - (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
-
+    if (_eventSink != nil) {
+        _eventSink(@{@"event" : @"enteringPIP"});
+    }
 }
 
 - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPictureController failedToStartPictureInPictureWithError:(NSError *)error {

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -501,7 +501,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _stalledCount = 0;
     _isStalledCheckStarted = false;
     _isPlaying = true;
-    [self updatePlayingState];
 }
 
 - (void)pause {

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -26,6 +26,6 @@ enum BetterPlayerEventType {
   bufferingEnd,
   changedPlaylistItem,
   setDuration,
-  enteringPIP,
-  exitingPIP,
+  enteringPIP, // Fire when start PIP by tap button in UI and close app.
+  exitingPIP, // Fire when start PIP by tap button in UI and open app from PIP.
 }

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -26,6 +26,6 @@ enum BetterPlayerEventType {
   bufferingEnd,
   changedPlaylistItem,
   setDuration,
-  enteringPIP, // Only in Android. Fire when start PIP by tap button in UI and close app.
-  exitingPIP, // Only in Android. Fire when start PIP by tap button in UI and open app from PIP.
+  enteringPIP,
+  exitingPIP,
 }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1187,6 +1187,14 @@ class BetterPlayerController {
       case VideoEventType.bufferingEnd:
         _postEvent(BetterPlayerEvent(BetterPlayerEventType.bufferingEnd));
         break;
+
+      case VideoEventType.enteringPIP:
+        _postEvent(BetterPlayerEvent(BetterPlayerEventType.enteringPIP));
+        break;
+
+      case VideoEventType.exitingPIP:
+        _postEvent(BetterPlayerEvent(BetterPlayerEventType.exitingPIP));
+        break;
       default:
 
         ///TODO: Handle when needed

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -423,6 +423,18 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             key: key,
           );
 
+        case 'enteringPIP':
+          return VideoEvent(
+            eventType: VideoEventType.enteringPIP,
+            key: key,
+          );
+
+        case 'exitingPIP':
+          return VideoEvent(
+            eventType: VideoEventType.exitingPIP,
+            key: key,
+          );
+
         default:
           return VideoEvent(
             eventType: VideoEventType.unknown,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -252,6 +252,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.pipStop:
           value = value.copyWith(isPip: false);
           break;
+        case VideoEventType.enteringPIP:
+          break;
+        case VideoEventType.exitingPIP:
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -471,6 +471,12 @@ enum VideoEventType {
   /// Picture in picture mode has been dismissed
   pipStop,
 
+  /// will start Picture in picture
+  enteringPIP,
+
+  /// will stop Picture in picture
+  exitingPIP,
+
   /// An unknown event has been received.
   unknown,
 }


### PR DESCRIPTION
## Description
Fixed a bug that video playback became slow and the app froze when pressing play/stop while displaying PIP
Fixed a bug that PIP was not displayed depending on timing.

### Problem
If I pause during PIP and then play it again, it repeats playback and stop.
Depending on timing, _pipController may not be initialized

### Solution
code fix

### What was done (Please be a little bit specific)

- Fixed to notify when PIP is shown/hidden.
- Fixed areas of inadequate operation.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-3938