### PR TITLE
Feature/daf 3938 2

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) bool _pictureInPicture;
 @property(nonatomic) bool _observersAdded;
 @property(nonatomic) int stalledCount;
+@property(nonatomic) bool _willStartPictureInPicture;
 @property(nonatomic) bool isStalledCheckStarted;
 @property(nonatomic) float playerRate;
 @property(nonatomic) int overriddenDuration;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -690,7 +690,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)willStartPictureInPicture: (bool) willStart
 {
-    self._willStartpictureInPicture = willStart;
+    self._willStartPictureInPicture = willStart;
     if (willStart) {
         if(!_pipController) {
             [self preparePictureInPicture:CGRectZero];

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -40,7 +40,7 @@ AVPictureInPictureController *_pipController;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
-    if (!_pipController) {
+    if (!_pipController && self._willStartPictureInPicture) {
         [self setupPipController];
     }
     return playerView;
@@ -504,6 +504,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _stalledCount = 0;
     _isStalledCheckStarted = false;
     _isPlaying = true;
+    if (!self._willStartPictureInPicture) {
+        [self updatePlayingState];
+    }
 }
 
 - (void)pause {
@@ -687,6 +690,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)willStartPictureInPicture: (bool) willStart
 {
+    self._willStartpictureInPicture = willStart;
     if (willStart) {
         if(!_pipController) {
             [self preparePictureInPicture:CGRectZero];


### PR DESCRIPTION
## Description
Fixed a bug in playback for free users who do not display PIP.

### Problem
PIP can be displayed even though you are a free user.
Once you stop playback, you can't resume playback

### Solution
code fix

### What was done (Please be a little bit specific)

- Added condition of whether or not to prepare for PIP display
- The process that was bugged when PIPing was necessary when PIPing was not, so it was conditionally reinstated.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-3938