### PR TITLE
DAF-3944  - Implement Play and Pause in iOS Command center

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -504,9 +504,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _stalledCount = 0;
     _isStalledCheckStarted = false;
     _isPlaying = true;
-    if (!self._willStartPictureInPicture) {
-        [self updatePlayingState];
-    }
+    [self updatePlayingState];
 }
 
 - (void)pause {

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -148,15 +148,21 @@ bool _remoteCommandsInitialized = false;
     [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"play"});
+
+            return MPRemoteCommandHandlerStatusSuccess;
+        }else{
+            return MPRemoteCommandHandlerStatusCommandFailed;
         }
-        return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"pause"});
+
+            return MPRemoteCommandHandlerStatusSuccess;
+        }else{
+            return MPRemoteCommandHandlerStatusCommandFailed;
         }
-        return MPRemoteCommandHandlerStatusSuccess;
     }];
 
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -148,9 +148,8 @@ bool _remoteCommandsInitialized = false;
     [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"play"});
-
             return MPRemoteCommandHandlerStatusSuccess;
-        }else{
+        } else {
             return MPRemoteCommandHandlerStatusCommandFailed;
         }
     }];
@@ -158,9 +157,8 @@ bool _remoteCommandsInitialized = false;
     [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"pause"});
-
             return MPRemoteCommandHandlerStatusSuccess;
-        }else{
+        } else {
             return MPRemoteCommandHandlerStatusCommandFailed;
         }
     }];


### PR DESCRIPTION
## Problem
This feature already implemented but the `_willStartPictureInPicture` flag make it can't work sometime.

## Solution
Remove the `_willStartPictureInPicture` checking on the `play` function.
This flag will be removed and its logic will be fixed on other PR.

## Addition done
- Return `MPRemoteCommandHandlerStatusCommandFailed` in the Failed case to let the OS know that the action has not been perform yet and it won't update the `Play`/`Pause` icon in the Command center.

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-3944