### PR TITLE
[DAF-3940] [iOS] Auto pip not run when video is loading (when seeking, bufferring..)

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -696,12 +696,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)willStartPictureInPicture: (bool) willStart
 {
     self._willStartPictureInPicture = willStart;
+    _pipController = nil;
+    
     if (willStart) {
-        if(!_pipController) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
             [self preparePictureInPicture:CGRectZero];
-        }
-    } else {
-        _pipController = nil;
+        });
     }
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -28,10 +28,7 @@ AVPictureInPictureController *_pipController;
     _disposed = false;
     _player = [[AVPlayer alloc] init];
     _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
-    ///Fix for loading large videos
-    if (@available(iOS 10.0, *)) {
-        _player.automaticallyWaitsToMinimizeStalling = false;
-    }
+    
     self._observersAdded = false;
     return self;
 }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -27,6 +27,7 @@ int _seekPosition;
     _isInitialized = false;
     _isPlaying = false;
     _disposed = false;
+    _seekPosition = -1;
     _player = [[AVPlayer alloc] init];
     _player.actionAtItemEnd = AVPlayerActionAtItemEndNone;
     
@@ -71,6 +72,7 @@ int _seekPosition;
     _isInitialized = false;
     _isPlaying = false;
     _disposed = false;
+    _seekPosition = -1;
     _failedCount = 0;
     _key = nil;
     if (_player.currentItem == nil) {

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -539,7 +539,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     bool wasPlaying = _isPlaying;
     if (wasPlaying){
         if (self._willStartPictureInPicture) {
-            // Prevent player pause if has pip mode
+            // PIP doesn't work if player pauses, so when seeking we make the player play but with minimum speed
             _player.rate = 0.1;
         } else {
             [_player pause];
@@ -689,6 +689,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _pipController = nil;
     
     if (willStart) {
+        // "0.2 seconds" is a magic number. But it is the same as the library's code. https://github.com/jhomlala/betterplayer/blob/f6a77cf6fbb515f01aa9fb459b2ee739de3e724c/ios/Classes/BetterPlayer.m#L647
+        // It is waiting to release the previous _pipController.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
             [self setupPipController];

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -38,9 +38,6 @@ int _seekPosition;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
-    if (!_pipController && self._willStartPictureInPicture) {
-        [self setupPipController];
-    }
     return playerView;
 }
 
@@ -684,24 +681,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
 }
 
-- (void)preparePictureInPicture: (CGRect) frame
-{
-    if(_player)
-    {
-        // Create new controller passing reference to the AVPlayerLayer
-        self._playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
-        UIViewController* vc = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-        self._playerLayer.frame = frame;
-        self._playerLayer.needsDisplayOnBoundsChange = YES;
-        [vc.view.layer addSublayer:self._playerLayer];
-        vc.view.layer.needsDisplayOnBoundsChange = YES;
-        if (@available(iOS 9.0, *)) {
-            _pipController = NULL;
-        }
-        [self setupPipController];
-    }
-}
-
 - (void)willStartPictureInPicture: (bool) willStart
 {
     self._willStartPictureInPicture = willStart;
@@ -710,7 +689,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (willStart) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            [self preparePictureInPicture:CGRectZero];
+            [self setupPipController];
         });
     }
 }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -537,7 +537,12 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     ///When player is playing, pause video, seek to new position and start again. This will prevent issues with seekbar jumps.
     bool wasPlaying = _isPlaying;
     if (wasPlaying){
-        [_player pause];
+        if (self._willStartPictureInPicture) {
+            // Prevent player pause if has pip mode
+            _player.rate = 0.1;
+        } else {
+            [_player pause];
+        }
     }
 
     [_player seekToTime:CMTimeMake(location, 1000)


### PR DESCRIPTION
## Description
Auto pip is not run when video is loading

### Problem
- AutoPiP doesn't work if video is pause
- Current logic code:
  - Pause video when seeking
  - Set flag `automaticallyWaitsToMinimizeStalling = false` -> video will pause when buffer is empty ([ref](https://developer.apple.com/documentation/avfoundation/avplayer/1643482-automaticallywaitstominimizestal))
     - If the value of this property is false, playback will start immediately when requested as long as the playback buffer is not empty. If the playback buffer becomes empty and playback stalls, the player’s timeControlStatus will switch to **AVPlayer.TimeControlStatus.paused** and the playback rate will change to 0.0.

- Note: There is a bug when play and pausing video on PIP mode (cannot play video after press multi times play pause button), I will resolve it on next PR
### Solution
- Prevent pause when seeking video
- Remove statement `automaticallyWaitsToMinimizeStalling = false`

### What was done (Please be a little bit specific)
- Change `rate` of player when seeking instead of `pause`
  - Handle case seekbar jump by another way

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-3940