### PR TITLE
[Fix] Pip player freeze when play pause and not sync with app player

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -432,6 +432,11 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
     NSLog(@"updatePlayingState %@", _isPlaying ? @"playing" : @"pause");
     if (_isPlaying) {
+        if (_pipController.pictureInPictureActive == true
+            && _player.timeControlStatus != AVPlayerTimeControlStatusPaused
+            && _player.rate == _playerRate) {
+            return;
+        }
         if (@available(iOS 10.0, *)) {
             [_player playImmediatelyAtRate:1.0];
             _player.rate = _playerRate;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -330,23 +330,20 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
     if ([path isEqualToString:@"rate"]) {
         if (@available(iOS 10.0, *)) {
-            NSLog(@"_playerStatus %ld", (long)_player.timeControlStatus);
             if (_pipController.pictureInPictureActive == true){
-                if (_lastAvPlayerTimeControlStatus == _player.timeControlStatus){
+                if (_lastAvPlayerTimeControlStatus != [NSNull null] && _lastAvPlayerTimeControlStatus == _player.timeControlStatus){
                     return;
                 }
-
-                _lastAvPlayerTimeControlStatus = _player.timeControlStatus;
                 
-                if (_player.timeControlStatus == AVPlayerTimeControlStatusPaused){
-                    NSLog(@"AVPlayerTimeControlStatusPaused");
+                if (_player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
+                    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPaused;
                     if (_eventSink != nil) {
                       _eventSink(@{@"event" : @"pause"});
                     }
+                    
                     return;
-
                 } else {
-                    NSLog(@"AVPlayerTimeControlStatusPlaying");
+                    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPlaying;
                     if (_eventSink != nil) {
                       _eventSink(@{@"event" : @"play"});
                     }
@@ -734,7 +731,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
-    _lastAvPlayerTimeControlStatus = _player.timeControlStatus;
+    // When change to PIP mode, need to correct control status
+    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPlaying;
     if (_eventSink != nil) {
         _eventSink(@{@"event" : @"enteringPIP"});
     }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -335,15 +335,15 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
                     return;
                 }
                 
+                _lastAvPlayerTimeControlStatus = _player.timeControlStatus;
+                
                 if (_player.timeControlStatus == AVPlayerTimeControlStatusPaused) {
-                    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPaused;
                     if (_eventSink != nil) {
                       _eventSink(@{@"event" : @"pause"});
                     }
                     
                     return;
                 } else {
-                    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPlaying;
                     if (_eventSink != nil) {
                       _eventSink(@{@"event" : @"play"});
                     }
@@ -732,7 +732,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
     // When change to PIP mode, need to correct control status
-    _lastAvPlayerTimeControlStatus = AVPlayerTimeControlStatusPlaying;
+    _lastAvPlayerTimeControlStatus = _player.timeControlStatus;
     if (_eventSink != nil) {
         _eventSink(@{@"event" : @"enteringPIP"});
     }


### PR DESCRIPTION
## Description
- PiP player freeze when playing pause multi times
- PiP player does not sync with app player:
  - PiP status is paused but then go back to app, app player status still is playing
- iOS Command center cannot play

### Problem
- When pressing play in PiP mode -> trigger call event play from native to flutter side -> flutter set play status and call native side again to play video
   -  There are some cases the trigger is not called leading to this bug

### Solution
- Update current logic

### What was done (Please be a little bit specific)
- Update logic with `_lastAvPlayerTimeControlStatus`
- Remove flag `_willStartPictureInPicture` check in `play` function

### Screenshot
video tested by @mvn-hienvu-hn 

https://github.com/dwango-nfc/betterplayer/assets/100773699/4643eec2-b8f2-4fe0-82de-f771f1d5fbb9

## Ticket
related ticket:
https://dw-ml-nfc.atlassian.net/browse/DAF-3944
