### PR TITLE
DAF-4178 Not deactive and display "Live" on seekbar while watching livestream

### DIFF
--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -453,6 +453,7 @@ class BetterPlayerController {
               _betterPlayerDataSource!.cacheConfiguration?.maxCacheFileSize ??
                   0,
           cacheKey: _betterPlayerDataSource?.cacheConfiguration?.key,
+          isLiveStream: _betterPlayerDataSource?.liveStream,
           showNotification: _betterPlayerDataSource
               ?.notificationConfiguration?.showNotification,
           title: _betterPlayerDataSource?.notificationConfiguration?.title,

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -87,6 +87,7 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
           'maxCacheFileSize': dataSource.maxCacheFileSize,
           'cacheKey': dataSource.cacheKey,
           'showNotification': dataSource.showNotification,
+          'isLiveStream': dataSource.isLiveStream,
           'title': dataSource.title,
           'author': dataSource.author,
           'imageUrl': dataSource.imageUrl,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -331,6 +331,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     int? maxCacheFileSize,
     String? cacheKey,
     bool? showNotification,
+    bool? isLiveStream,
     String? title,
     String? author,
     String? imageUrl,
@@ -347,6 +348,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       DataSource(
         sourceType: DataSourceType.network,
         uri: dataSource,
+        isLiveStream: isLiveStream,
         formatHint: formatHint,
         headers: headers,
         useCache: useCache,

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -227,6 +227,7 @@ class DataSource {
     this.cacheKey,
     this.showNotification = false,
     this.isExtraVideo = false,
+    this.isLiveStream = false,
     this.title,
     this.author,
     this.imageUrl,
@@ -295,6 +296,8 @@ class DataSource {
   final bool? showNotification;
 
   final bool? isExtraVideo;
+
+  final bool? isLiveStream;
 
   final String? title;
 

--- a/test/mock_video_player_controller.dart
+++ b/test/mock_video_player_controller.dart
@@ -64,6 +64,7 @@ class MockVideoPlayerController extends VideoPlayerController {
     int? maxCacheFileSize,
     String? cacheKey,
     bool? showNotification,
+    bool? isLiveStream,
     String? title,
     String? author,
     String? imageUrl,


### PR DESCRIPTION
## What was done

- Deactive `seek bar` and display "Live" label while watching livestream

## Ticket
https://dw-ml-nfc.atlassian.net/browse/DAF-4178

## Spec

JP: https://docs.google.com/spreadsheets/d/1iXu4Vz9wYpT6fHE7oK_W4vyHP_-BGTvk7HTcETFJ_0I/edit#gid=260929825

VN: https://docs.google.com/spreadsheets/d/1XLwXVbNo_r21YE8Ir4mDQcyAa9CbKDWA/edit#gid=814456320

## Screenshot

https://github.com/dwango-nfc/betterplayer/assets/100773699/cbdaaa42-47bc-4d9c-b038-fc96c31944a5

