### PR TITLE
[DAF 4107] [IOS] pip show black screen when play from notification center

### DIFF
--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -28,7 +28,7 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
     );
     BetterPlayerDataSource dataSource = BetterPlayerDataSource(
       BetterPlayerDataSourceType.network,
-      Constants.phantomVideoUrl,
+      Constants.elephantDreamStreamUrl,
       notificationConfiguration: BetterPlayerNotificationConfiguration(
         showNotification: true,
         title: 'Text title',
@@ -50,12 +50,19 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
           'betterPlayerEventType: ${event.betterPlayerEventType}, event.parameters: ${event.parameters.toString()}');
 
       if (event.betterPlayerEventType == BetterPlayerEventType.play) {
+        if (_willSwitchToPIPLayout) {
+          return;
+        }
         _betterPlayerController.setupAutomaticPictureInPictureTransition(
             willStartPIP: true);
+
         setState(() {
           _shouldStartPIP = true;
         });
       } else if (event.betterPlayerEventType == BetterPlayerEventType.pause) {
+        if (_willSwitchToPIPLayout) {
+          return;
+        }
         _betterPlayerController.setupAutomaticPictureInPictureTransition(
             willStartPIP: false);
         setState(() {

--- a/example/lib/pages/picture_in_picture_page.dart
+++ b/example/lib/pages/picture_in_picture_page.dart
@@ -15,7 +15,7 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
   GlobalKey _betterPlayerKey = GlobalKey();
   late bool _shouldStartPIP = false;
   // Whether need to switch to PIP layout. Only used in Android.
-  late bool _willSwitchToPIPLayout = false;
+  late bool _isPiPMode = false;
 
   @override
   void initState() {
@@ -50,35 +50,33 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
           'betterPlayerEventType: ${event.betterPlayerEventType}, event.parameters: ${event.parameters.toString()}');
 
       if (event.betterPlayerEventType == BetterPlayerEventType.play) {
-        if (_willSwitchToPIPLayout) {
-          return;
-        }
-        _betterPlayerController.setupAutomaticPictureInPictureTransition(
-            willStartPIP: true);
+        if (Platform.isAndroid || !_isPiPMode) {
+          _betterPlayerController.setupAutomaticPictureInPictureTransition(
+              willStartPIP: true);
 
-        setState(() {
-          _shouldStartPIP = true;
-        });
-      } else if (event.betterPlayerEventType == BetterPlayerEventType.pause) {
-        if (_willSwitchToPIPLayout) {
-          return;
+          setState(() {
+            _shouldStartPIP = true;
+          });
         }
-        _betterPlayerController.setupAutomaticPictureInPictureTransition(
-            willStartPIP: false);
-        setState(() {
-          _shouldStartPIP = false;
-        });
+      } else if (event.betterPlayerEventType == BetterPlayerEventType.pause) {
+        if (Platform.isAndroid || !_isPiPMode) {
+          _betterPlayerController.setupAutomaticPictureInPictureTransition(
+              willStartPIP: false);
+          setState(() {
+            _shouldStartPIP = false;
+          });
+        }
       } else if (event.betterPlayerEventType ==
           BetterPlayerEventType.enteringPIP) {
         _betterPlayerController.setControlsEnabled(false);
         setState(() {
-          _willSwitchToPIPLayout = true;
+          _isPiPMode = true;
         });
       } else if (event.betterPlayerEventType ==
           BetterPlayerEventType.exitingPIP) {
         _betterPlayerController.setControlsEnabled(true);
         setState(() {
-          _willSwitchToPIPLayout = false;
+          _isPiPMode = false;
         });
       } else if (event.betterPlayerEventType ==
           BetterPlayerEventType.tapExternalPlayButton) {
@@ -102,7 +100,7 @@ class _PictureInPicturePageState extends State<PictureInPicturePage> {
   @override
   Widget build(BuildContext context) {
     // Show on only BetterPlayerView for android.
-    if (Platform.isAndroid && _willSwitchToPIPLayout) {
+    if (Platform.isAndroid && _isPiPMode) {
       return AspectRatio(
         aspectRatio: 16 / 9,
         child: BetterPlayer(

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -249,6 +249,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _stalledCount = 0;
     _isStalledCheckStarted = false;
     _playerRate = 1;
+    
+    // Prevent pip change to black screen when play video from notification center
+    // When add video output to player item, maybe it makes player item high priority
+    // and player still generates frame when not visible
+    AVPlayerItemVideoOutput* playerItemVideoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:@{(id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32ARGB)}];
+    [item addOutput: playerItemVideoOutput];
+    
     [_player replaceCurrentItemWithPlayerItem:item];
 
     if (!@available(iOS 16.0, *)) {


### PR DESCRIPTION
## Description
- Video change to black in pip mode when playing from notification center
- Add `video play output` for `player item`
  - Cannot find any reference now, I think when adding `video output` for `player item`, it makes `player` has high priority and still generates video frames when not visible

- I use function `add video output` from: https://developer.apple.com/library/archive/samplecode/AVGreenScreenPlayer/Listings/AVGreenScreenPlayer_GSPlayerView_m.html#//apple_ref/doc/uid/DTS40012325-AVGreenScreenPlayer_GSPlayerView_m-DontLinkElementID_10

## Ticket
https://dw-ml-nfc.atlassian.net/browse/DAF-4107

## Screenshot

- before:

https://github.com/dwango-nfc/betterplayer/assets/38061170/f39043b2-98dc-4d53-a395-cf40479ee94b

- after

https://github.com/dwango-nfc/betterplayer/assets/38061170/4175b2be-aae6-4450-ae5c-fbb42e3d65ee

