### PR TITLE
DAF-4151 - Fixed control center jump to last seek position after reaching the end of video

### DIFF
--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -195,12 +195,12 @@ bool _remoteCommandsInitialized = false;
 - (void) setupRemoteCommandNotification:(BetterPlayer*)player, NSString* title, NSString* author , NSString* imageUrl, BOOL isLiveStream {
     // This function is always called double times at the end of video due to the default behavior of AVPlayer
     // This check is used to prevent the latest call.
-    if( player.position >= player.duration - 500){
+    if (player.position >= player.duration - 500) {
         return;
     }
-    float positionInSeconds = player.position /1000;
-    float durationInSeconds = player.duration/ 1000;
-    BOOL isPlayingTheLastSecond = player.position >= player.duration -1000;
+    float positionInSeconds = player.position / 1000;
+    float durationInSeconds = player.duration / 1000;
+    BOOL isPlayingTheLastSecond = player.position >= player.duration - 1000;
 
     NSMutableDictionary * nowPlayingInfoDict = [@{MPMediaItemPropertyArtist: author,
                                                   MPMediaItemPropertyTitle: title,

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -193,9 +193,14 @@ bool _remoteCommandsInitialized = false;
 }
 
 - (void) setupRemoteCommandNotification:(BetterPlayer*)player, NSString* title, NSString* author , NSString* imageUrl, BOOL isLiveStream {
+    // This function is always called double times at the end of video due to the default behavior of AVPlayer
+    // This check is used to prevent the latest call.
+    if( player.position >= player.duration - 500){
+        return;
+    }
     float positionInSeconds = player.position /1000;
     float durationInSeconds = player.duration/ 1000;
-    BOOL isPlayingTheLastSecond = positionInSeconds >= durationInSeconds -1;
+    BOOL isPlayingTheLastSecond = player.position >= player.duration -1000;
 
     NSMutableDictionary * nowPlayingInfoDict = [@{MPMediaItemPropertyArtist: author,
                                                   MPMediaItemPropertyTitle: title,

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -201,9 +201,18 @@ bool _remoteCommandsInitialized = false;
                                                   MPMediaItemPropertyTitle: title,
                                                   MPNowPlayingInfoPropertyElapsedPlaybackTime: [ NSNumber numberWithFloat : positionInSeconds],
                                                   MPMediaItemPropertyPlaybackDuration: [NSNumber numberWithFloat:durationInSeconds],
-                                                  MPNowPlayingInfoPropertyPlaybackRate: @1,
+                                                  MPNowPlayingInfoPropertyPlaybackRate: positionInSeconds >= durationInSeconds -1 ? @0 : @1,
                                                   MPNowPlayingInfoPropertyIsLiveStream: [NSNumber numberWithBool:isLiveStream],
     } mutableCopy];
+
+    if (positionInSeconds >= durationInSeconds -1) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            [nowPlayingInfoDict setObject:[NSNumber numberWithFloat:durationInSeconds]
+                                forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
+            [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfoDict;
+        });
+    }
 
     if (imageUrl != [NSNull null]){
         NSString* key =  [self getTextureId:player];


### PR DESCRIPTION
## Problem
- The progress bar of `Control center` auto `jump` to the last `seek`/`pause`/`play` position after reaching the end of video. This is `default` behavior of `Control center`, it can auto update the progress of `progress bar`, so we can reproduce this bug with [iOS sample code](https://developer.apple.com/documentation/mediaplayer/becoming_a_now_playable_app).

- And the `position` always stop at `-0:01` (`= duration - 1`), then the `progress bar` will never reach to the end.

## Solution
- Stop the `progress bar` of Control center by setting its `playback rate` to `0` one second before the end.
- Then update the `progress bar` manually.

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-4151

## Spec

JP: https://docs.google.com/spreadsheets/d/1iXu4Vz9wYpT6fHE7oK_W4vyHP_-BGTvk7HTcETFJ_0I/edit#gid=260929825

VN: https://docs.google.com/spreadsheets/d/1XLwXVbNo_r21YE8Ir4mDQcyAa9CbKDWA/edit#gid=814456320

## Screenshot

- Before:

https://github.com/dwango-nfc/betterplayer/assets/100773699/9530b6c3-d6f3-4f69-8aa7-115b6c74cbc0

- After: 

https://github.com/dwango-nfc/betterplayer/assets/100773699/000ca03e-990f-491d-9b1e-dca07ea940e2
