### PR TITLE
Feature/daf 4214 add new method channel

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -310,10 +310,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 result.success(null)
             }
             BROADCAST_ENDED -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    removeExternalPlayButton()
-                }
-                result.success(null)
+                // TODO: implement
             }
             SEEK_TO_METHOD -> {
                 val location = (call.argument<Any>(LOCATION_PARAMETER) as Number?)!!.toInt()

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -309,6 +309,12 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 player.pause()
                 result.success(null)
             }
+            BROADCAST_ENDED -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    removeExternalPlayButton()
+                }
+                result.success(null)
+            }
             SEEK_TO_METHOD -> {
                 val location = (call.argument<Any>(LOCATION_PARAMETER) as Number?)!!.toInt()
                 player.seekTo(location)
@@ -743,6 +749,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val SET_VOLUME_METHOD = "setVolume"
         private const val PLAY_METHOD = "play"
         private const val PAUSE_METHOD = "pause"
+        private const val BROADCAST_ENDED = "broadcastEnded"
         private const val SEEK_TO_METHOD = "seekTo"
         private const val POSITION_METHOD = "position"
         private const val ABSOLUTE_POSITION_METHOD = "absolutePosition"

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1056,6 +1056,15 @@ class BetterPlayerController {
     return _overriddenFit ?? betterPlayerConfiguration.fit;
   }
 
+  /// To handle process when broadcast ended.
+  Future<void>? broadcastEnded() async {
+    if (videoPlayerController == null) {
+      throw StateError("The data source has not been initialized");
+    }
+
+    videoPlayerController?.broadcastEnded();
+  }
+
   ///Set up to start Picture in Picture automatically when close app.
   ///When device is not supported, PiP mode won't be open.
   Future<void>? setupAutomaticPictureInPictureTransition(

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -228,6 +228,14 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<void> broadcastEnded({int? textureId}) async {
+    return _channel.invokeMethod<void>(
+      'broadcastEnded',
+      <String, dynamic>{'textureId': textureId},
+    );
+  }
+
+  @override
   Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,
     bool? willStartPIP,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -606,6 +606,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         _textureId, width, height, bitrate);
   }
 
+  Future<void> broadcastEnded() async {
+    await _videoPlayerPlatform.broadcastEnded(
+      textureId: textureId,
+    );
+  }
+
   Future<void> setupAutomaticPictureInPictureTransition(
       {bool? willStartPIP}) async {
     await _videoPlayerPlatform.setupAutomaticPictureInPictureTransition(

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -138,6 +138,11 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('getAbsolutePosition() has not been implemented.');
   }
 
+  /// To  process when broadcast ended.
+  Future<void> broadcastEnded({int? textureId}) {
+    throw UnimplementedError('broadcastEnded() has not been implemented.');
+  }
+
   ///Set up auto PiP transition.
   Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -138,7 +138,7 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('getAbsolutePosition() has not been implemented.');
   }
 
-  /// To  process when broadcast ended.
+  /// To process when broadcast ended.
   Future<void> broadcastEnded({int? textureId}) {
     throw UnimplementedError('broadcastEnded() has not been implemented.');
   }


### PR DESCRIPTION
### Issue
We need to do some process to hide play button when broadcast ended. 
Although when broadcast ended by CP, in better player, (at least in Android), there is no signal to know the end of broadcast.

### Solution
Add new method channel to tell broadcast was ended to better player library.
This method channel will be call from app side when catch websocket for end of broadcast.

### Specification
https://docs.google.com/spreadsheets/d/1iXu4Vz9wYpT6fHE7oK_W4vyHP_-BGTvk7HTcETFJ_0I/edit#gid=328690871&range=209:210

### TICKET
https://dw-ml-nfc.atlassian.net/browse/DAF-4214