### PR TITLE
DAF-4215 - Hide iOS PiP and Control center buttons when playback ended

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -57,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setPictureInPicture:(BOOL)pictureInPicture;
 - (void)disablePictureInPicture;
 - (void)willStartPictureInPicture:(bool)willStart;
+- (void)setIsDisplayPipButtons:(BOOL) isDisplay;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -770,6 +770,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     [self setRestoreUserInterfaceForPIPStopCompletionHandler: true];
 }
 
+- (void)setIsDisplayPipButtons:(BOOL) isDisplay {
+    [_pipController setValue:[NSNumber numberWithInt:isDisplay ? 0 : 1] forKey:@"controlsStyle"];
+}
+
 - (void) setAudioTrack:(NSString*) name index:(int) index{
     AVMediaSelectionGroup *audioSelectionGroup = [[[_player currentItem] asset] mediaSelectionGroupForMediaCharacteristic: AVMediaCharacteristicAudible];
     NSArray* options = audioSelectionGroup.options;

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -94,6 +94,11 @@ bool _isCommandCenterButtonsEnabled = true;
 }
 
 - (void)itemDidPlayToEndTime:(NSNotification*) notification {
+    // Delay 1 second for users to see the video is finished.
+    // - Without this delay, the progress bar will run like "-0:01" then everything disappear.
+    // - With this delay, the progress bar will run like "-0:01" then "-0:00"
+    // and Pause button switched to Play button(it mean the player had stopped)
+    // then clear all info.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
         // clear nowPlayingInfo

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -18,6 +18,7 @@ CacheManager* _cacheManager;
 int texturesCount = -1;
 BetterPlayer* _notificationPlayer;
 bool _remoteCommandsInitialized = false;
+bool _isCommandCenterButtonsEnabled = true;
 
 
 #pragma mark - FlutterPlugin protocol
@@ -103,7 +104,7 @@ bool _remoteCommandsInitialized = false;
         [commandCenter.togglePlayPauseCommand setEnabled:NO];
         [commandCenter.playCommand setEnabled:NO];
         [commandCenter.pauseCommand setEnabled:NO];
-        _remoteCommandsInitialized = false;
+        _isCommandCenterButtonsEnabled = false;
 
         // hide PiP buttons
         [_notificationPlayer setIsDisplayPipButtons:false];
@@ -163,7 +164,7 @@ bool _remoteCommandsInitialized = false;
 
 
 - (void) setupRemoteCommands:(BetterPlayer*)player isExtraVideo:(BOOL)isExtraVideo isLiveStream:(BOOL)isLiveStream {
-    if (_remoteCommandsInitialized){
+    if (_remoteCommandsInitialized && _isCommandCenterButtonsEnabled){
         return;
     }
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
@@ -172,6 +173,7 @@ bool _remoteCommandsInitialized = false;
     [commandCenter.pauseCommand setEnabled:YES];
     [commandCenter.nextTrackCommand setEnabled:NO];
     [commandCenter.previousTrackCommand setEnabled:NO];
+    _isCommandCenterButtonsEnabled = true;
     if (@available(iOS 9.1, *)) {
         [commandCenter.changePlaybackPositionCommand setEnabled: isLiveStream || isExtraVideo ? NO : YES];
     }
@@ -464,12 +466,14 @@ bool _remoteCommandsInitialized = false;
         } else if ([@"seekTo" isEqualToString:call.method]) {
             [player seekTo:[argsMap[@"location"] intValue]];
 
-            // re-enable PiP and Control center buttons
-            [player setIsDisplayPipButtons:true];
-            MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
-            [commandCenter.togglePlayPauseCommand setEnabled:YES];
-            [commandCenter.playCommand setEnabled:YES];
-            [commandCenter.pauseCommand setEnabled:YES];
+            if(!_isCommandCenterButtonsEnabled){
+                [player setIsDisplayPipButtons:true];
+                MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
+                [commandCenter.togglePlayPauseCommand setEnabled:YES];
+                [commandCenter.playCommand setEnabled:YES];
+                [commandCenter.pauseCommand setEnabled:YES];
+                _isCommandCenterButtonsEnabled = true;
+            }
             result(nil);
         } else if ([@"pause" isEqualToString:call.method]) {
             [player pause];


### PR DESCRIPTION
## What was done
- Listen to `AVPlayerItemDidPlayToEndTimeNotification`  event and `broadcastEnded` event to hide the iOS PiP buttons and Control center buttons.
- Re-enable those buttons on `play`/`seakTo` event.
- Trigger `broadcastEnded` event [in flutter side](https://github.com/dwango-nfc/dwango-app-ch/pull/1698).

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-4215

## Spec

JP: https://docs.google.com/spreadsheets/d/1iXu4Vz9wYpT6fHE7oK_W4vyHP_-BGTvk7HTcETFJ_0I/edit#gid=260929825

VN: https://docs.google.com/spreadsheets/d/1XLwXVbNo_r21YE8Ir4mDQcyAa9CbKDWA/edit#gid=814456320

## Screenshot

- VOD:

https://github.com/dwango-nfc/betterplayer/assets/100773699/36c00e43-1ae1-44e6-bcd8-a25ca46bac51

- LIVE: 

https://github.com/dwango-nfc/betterplayer/assets/100773699/08c970a0-a7d1-43b2-bf12-c67fb50ab57b


