### PR TITLE
DAF-4227 - Fixed Not display info of livestream, video when thumbnail has not finished loading

### DIFF
--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -17,6 +17,7 @@ NSMutableDictionary*  _artworkImageDict;
 CacheManager* _cacheManager;
 int texturesCount = -1;
 BetterPlayer* _notificationPlayer;
+bool _isLoadingCommandCenterImage = false;
 bool _remoteCommandsInitialized = false;
 
 
@@ -195,7 +196,7 @@ bool _remoteCommandsInitialized = false;
 - (void) setupRemoteCommandNotification:(BetterPlayer*)player, NSString* title, NSString* author , NSString* imageUrl, BOOL isLiveStream {
     // This function is always called double times at the end of video due to the default behavior of AVPlayer
     // This check is used to prevent the latest call.
-    if (player.position >= player.duration - 500) {
+    if (player.duration != 0 && player.position >= player.duration - 500) {
         return;
     }
     float positionInSeconds = player.position / 1000;
@@ -237,8 +238,16 @@ bool _remoteCommandsInitialized = false;
                 [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfoDict;
 
             } else {
+                // In this case, the image hasn't been cached yet, so just displaying other info immediately
+                // then update the image later after it is loaded
+                [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfoDict;
+
+                if(_isLoadingCommandCenterImage){
+                    return;
+                }
                 dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
                 dispatch_async(queue, ^{
+                    _isLoadingCommandCenterImage = true;
                     @try{
                         UIImage * tempArtworkImage = nil;
                         if ([imageUrl rangeOfString:@"http"].location == NSNotFound){
@@ -251,13 +260,16 @@ bool _remoteCommandsInitialized = false;
                         {
                             MPMediaItemArtwork* artworkImage = [[MPMediaItemArtwork alloc] initWithImage: tempArtworkImage];
                             [_artworkImageDict setObject:artworkImage forKey:key];
-                            [nowPlayingInfoDict setObject:artworkImage forKey:MPMediaItemPropertyArtwork];
+
+                            NSMutableDictionary * currentNowPlayingInfoDict = [[MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo mutableCopy];
+                            [currentNowPlayingInfoDict setObject:artworkImage forKey:MPMediaItemPropertyArtwork];
+                            [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = currentNowPlayingInfoDict;
                         }
-                        [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfoDict;
                     }
                     @catch(NSException *exception) {
 
                     }
+                    _isLoadingCommandCenterImage = false;
                 });
             }
         }
@@ -288,6 +300,7 @@ bool _remoteCommandsInitialized = false;
     if (player == _notificationPlayer){
         _notificationPlayer = NULL;
         _remoteCommandsInitialized = false;
+        _isLoadingCommandCenterImage = false;
     }
     NSString* key =  [self getTextureId:player];
     id _timeObserverId = _timeObserverIdDict[key];

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -256,8 +256,11 @@ bool _remoteCommandsInitialized = false;
                             NSURL *nsImageUrl =[NSURL URLWithString:imageUrl];
                             tempArtworkImage = [UIImage imageWithData:[NSData dataWithContentsOfURL:nsImageUrl]];
                         }
-                        if(tempArtworkImage)
-                        {
+
+                        NSDictionary* dataSource = [_dataSourceDict objectForKey:[self getTextureId:_notificationPlayer]];
+                        NSString* currentImageUrl = dataSource[@"imageUrl"];
+
+                        if(tempArtworkImage && [imageUrl isEqualToString: currentImageUrl])                        {
                             MPMediaItemArtwork* artworkImage = [[MPMediaItemArtwork alloc] initWithImage: tempArtworkImage];
                             [_artworkImageDict setObject:artworkImage forKey:key];
 


### PR DESCRIPTION
## Problem
The Control center won't display info of livestream, video if thumbnail has not finished loading

## Solution
- If the thumbnail image hasn't been cached yet, display other info immediately.
- then update the image later after it is loaded

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-4227

## Spec

JP: https://docs.google.com/spreadsheets/d/1iXu4Vz9wYpT6fHE7oK_W4vyHP_-BGTvk7HTcETFJ_0I/edit#gid=260929825

VN: https://docs.google.com/spreadsheets/d/1XLwXVbNo_r21YE8Ir4mDQcyAa9CbKDWA/edit#gid=814456320

## Screenshot

- Before:

https://github.com/dwango-nfc/betterplayer/assets/100773699/b465a082-3aba-4265-af89-72866f967b2a

- After: 

https://github.com/dwango-nfc/betterplayer/assets/100773699/82729f32-4716-4164-ad86-ed6e2f9da554

