### PR TITLE
DAF-4248 fixed didn't hide PiP/Control center buttons at playback end with limited plan video

### DIFF
--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -481,6 +481,9 @@ bool _isCommandCenterButtonsEnabled = true;
         } else if ([@"broadcastEnded" isEqualToString:call.method]) {
             [self itemDidPlayToEndTime:nil];
             result(nil);
+        } else if ([@"limitedPlanVideoReachEnd" isEqualToString:call.method]) {
+            [self itemDidPlayToEndTime:nil];
+            result(nil);
         } else if ([@"setLooping" isEqualToString:call.method]) {
             [player setIsLooping:[argsMap[@"looping"] boolValue]];
             result(nil);

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1066,6 +1066,15 @@ class BetterPlayerController {
     videoPlayerController?.broadcastEnded();
   }
 
+  /// To handle process when limited plan video ended.
+  Future<void>? limitedPlanVideoReachEnd() async {
+    if (videoPlayerController == null) {
+      throw StateError("The data source has not been initialized");
+    }
+
+    videoPlayerController?.limitedPlanVideoReachEnd();
+  }
+
   ///Set up to start Picture in Picture automatically when close app.
   ///When device is not supported, PiP mode won't be open.
   Future<void>? setupAutomaticPictureInPictureTransition(

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -236,6 +236,14 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<void> limitedPlanVideoReachEnd({int? textureId}) async {
+    return _channel.invokeMethod<void>(
+      'limitedPlanVideoReachEnd',
+      <String, dynamic>{'textureId': textureId},
+    );
+  }
+
+  @override
   Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,
     bool? willStartPIP,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -612,6 +612,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     );
   }
 
+  Future<void> limitedPlanVideoReachEnd() async {
+    await _videoPlayerPlatform.limitedPlanVideoReachEnd(
+      textureId: textureId,
+    );
+  }
+
   Future<void> setupAutomaticPictureInPictureTransition(
       {bool? willStartPIP}) async {
     await _videoPlayerPlatform.setupAutomaticPictureInPictureTransition(

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -143,6 +143,12 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('broadcastEnded() has not been implemented.');
   }
 
+  /// To process when limited plan video ended.
+  Future<void> limitedPlanVideoReachEnd({int? textureId}) {
+    throw UnimplementedError(
+        'limitedPlanVideoReachEnd() has not been implemented.');
+  }
+
   ///Set up auto PiP transition.
   Future<void> setupAutomaticPictureInPictureTransition({
     int? textureId,


### PR DESCRIPTION
## What was done
- Add new method channel (`limitedPlanVideoReachEnd`) to handle process when limited plan video ended.
- Trigger `limitedPlanVideoReachEnd` [in the app side](https://github.com/dwango-nfc/dwango-app-ch/pull/1717).
- Listen to `limitedPlanVideoReachEnd` event in iOS side and trigger `itemDidPlayToEndTime` to hide PiP/Control center buttons.

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-4248?focusedCommentId=108893

## Screenshot
- Before

https://github.com/dwango-nfc/betterplayer/assets/100773699/6e1a71dc-c075-405c-8266-9685801943a2

- After

https://github.com/dwango-nfc/betterplayer/assets/100773699/5c68b866-cfd1-4302-a2e2-5b45faeffc04