### PR TITLE
DAF-4303 Fixed Control center still work for free member

### DIFF
--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -14,7 +14,6 @@
 NSMutableDictionary* _dataSourceDict;
 NSMutableDictionary*  _timeObserverIdDict;
 NSMutableDictionary*  _artworkImageDict;
-NSMutableDictionary*  _commandCenterTargetIdDict;
 CacheManager* _cacheManager;
 int texturesCount = -1;
 BetterPlayer* _notificationPlayer;
@@ -43,7 +42,6 @@ bool _isCommandCenterButtonsEnabled = true;
     _timeObserverIdDict = [NSMutableDictionary dictionary];
     _artworkImageDict = [NSMutableDictionary dictionary];
     _dataSourceDict = [NSMutableDictionary dictionary];
-    _commandCenterTargetIdDict = [NSMutableDictionary dictionary];
     _cacheManager = [[CacheManager alloc] init];
     [_cacheManager setup];
     return self;
@@ -163,11 +161,10 @@ bool _isCommandCenterButtonsEnabled = true;
 
 - (void) removeCommandCenterTargetHandlers{
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
-    [commandCenter.togglePlayPauseCommand removeTarget:_commandCenterTargetIdDict[@"togglePlayPauseCommand"]];
-    [commandCenter.playCommand removeTarget:_commandCenterTargetIdDict[@"playCommand"]];
-    [commandCenter.pauseCommand removeTarget:_commandCenterTargetIdDict[@"pauseCommand"]];
-    [commandCenter.changePlaybackPositionCommand removeTarget:_commandCenterTargetIdDict[@"changePlaybackPositionCommand"]];
-    [_commandCenterTargetIdDict removeAllObjects];
+    [commandCenter.togglePlayPauseCommand removeTarget:nil];
+    [commandCenter.playCommand removeTarget:nil];
+    [commandCenter.pauseCommand removeTarget:nil];
+    [commandCenter.changePlaybackPositionCommand removeTarget:nil];
 }
 
 - (void) setupRemoteCommands:(BetterPlayer*) player {
@@ -191,7 +188,7 @@ bool _isCommandCenterButtonsEnabled = true;
     // Remove old target handlers
     [self removeCommandCenterTargetHandlers];
     
-    id togglePlayPauseCommandTargetId = [commandCenter.togglePlayPauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+    [commandCenter.togglePlayPauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             if (_notificationPlayer.isPlaying){
                 _notificationPlayer.eventSink(@{@"event" : @"play"});
@@ -202,14 +199,14 @@ bool _isCommandCenterButtonsEnabled = true;
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
-    id playCommandTargetId = [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+    [commandCenter.playCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"play"});
         }
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
-    id pauseCommandTargetId = [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+    [commandCenter.pauseCommand addTargetWithHandler: ^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         if (_notificationPlayer != [NSNull null]){
             _notificationPlayer.eventSink(@{@"event" : @"pause"});
         }
@@ -219,7 +216,7 @@ bool _isCommandCenterButtonsEnabled = true;
 
 
     if (@available(iOS 9.1, *)) {
-        id changePlaybackPositionCommandId = [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+        [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
             if (_notificationPlayer != [NSNull null]){
                 MPChangePlaybackPositionCommandEvent * playbackEvent = (MPChangePlaybackRateCommandEvent * ) event;
                 CMTime time = CMTimeMake(playbackEvent.positionTime, 1);
@@ -228,12 +225,7 @@ bool _isCommandCenterButtonsEnabled = true;
             }
             return MPRemoteCommandHandlerStatusSuccess;
         }];
-        [_commandCenterTargetIdDict setObject:changePlaybackPositionCommandId forKey:@"changePlaybackPositionCommand"];
     }
-    [_commandCenterTargetIdDict setObject:togglePlayPauseCommandTargetId forKey:@"togglePlayPauseCommand"];
-    [_commandCenterTargetIdDict setObject:playCommandTargetId forKey:@"playCommand"];
-    [_commandCenterTargetIdDict setObject:pauseCommandTargetId forKey:@"pauseCommand"];
-
     _remoteCommandsInitialized = true;
 }
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -155,10 +155,7 @@ bool _isCommandCenterButtonsEnabled = true;
 }
 
 - (void) setRemoteCommandsNotificationNotActive{
-    if ([_players count] == 0) {
-        [[AVAudioSession sharedInstance] setActive:false error:nil];
-    }
-
+    [[AVAudioSession sharedInstance] setActive:false error:nil];
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
 }
 


### PR DESCRIPTION
## Problem
The Control center hasn't been unlinked when closing Player view. Therefore, when switching from a paid user to a free user, the Control center still link to our app.

## Solution
- always `setActive:false` for `AudioSession` when dispose
- remove all Command Center target handlers before add the new ones and also when dispose.

## Ticket

https://dw-ml-nfc.atlassian.net/browse/DAF-4303

## Screenshot

https://github.com/dwango-nfc/betterplayer/assets/100773699/6b0997d3-5dfa-4f89-aba6-d6a1e097d62c
