### PR TITLE
DAF-4324: Fixed display black screen on player when the streaming device has a bad network

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -133,7 +133,10 @@ int _seekPosition;
 
 - (void)itemFailedToPlayToEndTime:(NSNotification*)notification {
     if (_eventSink) {
-        _eventSink(@{@"event" : @"failedToPlayToEndTime", @"key" : _key});
+        _eventSink([FlutterError
+                    errorWithCode:@"VideoError"
+                    message:@"Failed to load video: itemFailedToPlayToEndTime"
+                    details:nil]);
     }
 }
 

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -33,6 +33,5 @@ enum BetterPlayerEventType {
   tapExternalPlayButton, // Android only. Fire when tap play button from outside the app (e.g. PIP, Notification).
   tapExternalPauseButton, // Android only. Fire when tap pause button from outside the app (e.g. PIP, Notification).
   finishedPlayInLooping, // Ios only. Trigger when postion = duration in looping mode,
-  failedToPlayToEndTime, // Ios only. Trigger when player cannot play to the end (black screen in PIP, ...)
   pressedBackToAppButton, // Ios only. Trigger when back to app button ( right button in pip mode) was pressed
 }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1239,10 +1239,6 @@ class BetterPlayerController {
         _postEvent(
             BetterPlayerEvent(BetterPlayerEventType.finishedPlayInLooping));
         break;
-      case VideoEventType.failedToPlayToEndTime:
-        _postEvent(
-            BetterPlayerEvent(BetterPlayerEventType.failedToPlayToEndTime));
-        break;
       case VideoEventType.pressedBackToAppButton:
         _postEvent(
             BetterPlayerEvent(BetterPlayerEventType.pressedBackToAppButton));

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -477,11 +477,6 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             key: key,
           );
 
-        case 'failedToPlayToEndTime':
-          return VideoEvent(
-            eventType: VideoEventType.failedToPlayToEndTime,
-            key: key,
-          );
         case 'pressedBackToAppButton':
           return VideoEvent(
             eventType: VideoEventType.pressedBackToAppButton,

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -510,12 +510,9 @@ enum VideoEventType {
   /// When video reaches end of duration in looping mode (IOS only)
   finishedPlayInLooping,
 
-  /// When player has an error which can't play to end time
-  failedToPlayToEndTime,
-
   /// An unknown event has been received.
   unknown,
-  
+
   /// back to app button ( right button in pip mode) was pressed (iOS only)
   pressedBackToAppButton,
 }


### PR DESCRIPTION
## Description

### Problem
- The `AVPlayerItemFailedToPlayToEndTime` event cause the player display black screen on both detail screen and PiP mode. If the AVPlayer can't fetch buffer data for a while, we'll get this event. 

### Solution
Make this event act like other video error to show data fetching error on screen and make auto reload on error work for this case.

### What was done (Please be a little bit specific)

- [throw error on itemFailedToPlayToEndTime](https://github.com/dwango-nfc/betterplayer/commit/b76c3fc42007780075baf20b8ba426a279dff148)
- [remove itemFailedToPlayToEndTime event type because no longer need](https://github.com/dwango-nfc/betterplayer/commit/ada0c5716219bd30f015f935b951b3559bc09c24)
- [app side implement](https://github.com/dwango-nfc/dwango-app-ch/pull/1757)

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4324

# Screenshot or Video (Before/After)

On the streaming device, adjust the bandwidth to low speed (E.x: Downlink - Bandwidth: `780kbps`, Uplink - Bandwidth: `330kbps`, Delay: `100ms`)

- Detail screen:

https://github.com/dwango-nfc/dwango-app-ch/assets/100773699/18f409f9-0c8a-4fd7-98c0-3dc76e067d03

- PiP:

https://github.com/dwango-nfc/dwango-app-ch/assets/100773699/3d2c219c-e240-48dc-a33e-e1d2fdaf666e
