### PR TITLE
DAF-4341 Add method to get DVR duration.

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
@@ -623,7 +623,7 @@ internal class BetterPlayer(
         }
     }
 
-    private fun getDuration(): Long = exoPlayer?.duration ?: 0L
+    fun getDuration(): Long = exoPlayer?.duration ?: 0L
 
     /**
      * Create media session which will be used in notifications, pip mode.

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -360,6 +360,9 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 player.sendBufferingUpdate(false)
             }
             ABSOLUTE_POSITION_METHOD -> result.success(player.absolutePosition)
+            GET_DURATION_METHOD -> {
+                result.success(player.getDuration())
+            }
             SET_SPEED_METHOD -> {
                 player.setSpeed(call.argument(SPEED_PARAMETER)!!)
                 result.success(null)
@@ -799,6 +802,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val BROADCAST_ENDED = "broadcastEnded"
         private const val SEEK_TO_METHOD = "seekTo"
         private const val POSITION_METHOD = "position"
+        private const val GET_DURATION_METHOD = "getDuration"
         private const val ABSOLUTE_POSITION_METHOD = "absolutePosition"
         private const val SET_SPEED_METHOD = "setSpeed"
         private const val SET_TRACK_PARAMETERS_METHOD = "setTrackParameters"

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -360,7 +360,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 player.sendBufferingUpdate(false)
             }
             ABSOLUTE_POSITION_METHOD -> result.success(player.absolutePosition)
-            GET_DURATION_METHOD -> {
+            GET_DVR_DURATION_METHOD -> {
                 result.success(player.getDuration())
             }
             SET_SPEED_METHOD -> {
@@ -802,7 +802,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val BROADCAST_ENDED = "broadcastEnded"
         private const val SEEK_TO_METHOD = "seekTo"
         private const val POSITION_METHOD = "position"
-        private const val GET_DURATION_METHOD = "getDuration"
+        private const val GET_DVR_DURATION_METHOD = "getDvrDuration"
         private const val ABSOLUTE_POSITION_METHOD = "absolutePosition"
         private const val SET_SPEED_METHOD = "setSpeed"
         private const val SET_TRACK_PARAMETERS_METHOD = "setTrackParameters"

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updatePlayingState;
 - (int64_t) duration;
 - (int64_t) position;
+- (int64_t) getDvrDuration;
 
 - (instancetype)initWithFrame:(CGRect)frame;
 - (void)setMixWithOthers:(bool)mixWithOthers;

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updatePlayingState;
 - (int64_t) duration;
 - (int64_t) position;
-- (int64_t) getDvrDuration;
+- (int64_t) dvrDuration;
 
 - (instancetype)initWithFrame:(CGRect)frame;
 - (void)setMixWithOthers:(bool)mixWithOthers;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -559,8 +559,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     return [BetterPlayerTimeUtils FLTCMTimeToMillis:(time)];
 }
 
-// Get DVR video duration. (This is not work for Live point mode.)
-- (int64_t)getDvrDuration {
+// DVR video duration. (This is not work for Live point mode.)
+- (int64_t)dvrDuration {
     CMTimeRange seekableRange = [_player.currentItem.seekableTimeRanges.lastObject CMTimeRangeValue];
     return [BetterPlayerTimeUtils FLTCMTimeToMillis:(seekableRange.duration)];
 }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -547,7 +547,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (int64_t)duration {
     CMTime time;
     if (@available(iOS 13, *)) {
-        time =  [[_player currentItem] duration]; // NOTE: This value is always 0 when playing live streming include DVR mode.
+        // NOTE: This value is always 0 when playing live streming include DVR mode.
+        time =  [[_player currentItem] duration];
     } else {
         time =  [[[_player currentItem] asset] duration];
     }
@@ -559,26 +560,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 // Get DVR video duration. (This is not work for Live point mode.)
-// Reference: https://stackoverflow.com/a/44941053/3769374
 - (int64_t)getDvrDuration {
     CMTimeRange seekableRange = [_player.currentItem.seekableTimeRanges.lastObject CMTimeRangeValue];
-
-    // TODO: Delete log
-    CGFloat currentTime = CMTimeGetSeconds(_player.currentTime);
-    NSLog(@"NFCDEV currentTime %.2f", currentTime);
-    
-    CGFloat seekableStart = CMTimeGetSeconds(seekableRange.start);
-    CGFloat seekableDuration = CMTimeGetSeconds(seekableRange.duration);
-    CGFloat livePosition = seekableStart + seekableDuration;
-    NSLog(@"NFCDEV seekableDuration: %.2f", seekableDuration);
-    NSLog(@"NFCDEV seekableStart: %.2f", (seekableStart));
-    NSLog(@"NFCDEV seekableRange.start + seekableRange.duration  f: %lld", [BetterPlayerTimeUtils FLTCMTimeToMillis:(CMTimeAdd(seekableRange.start, seekableRange.duration))]);
-    
-    CGFloat secondsBehindLive = currentTime - seekableDuration - seekableStart;
-    NSLog(@"NFCDEV secondsBehindLive: %.2f", (secondsBehindLive));
-    // TODO: Delete log
-
-//    return [BetterPlayerTimeUtils FLTCMTimeToMillis:(CMTimeAdd(seekableRange.start, seekableRange.duration))]; // seekableRange.startは配信終了後、アーカイブ自動公開だと0以外になりうる？
     return [BetterPlayerTimeUtils FLTCMTimeToMillis:(seekableRange.duration)];
 }
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -512,6 +512,8 @@ bool _isCommandCenterButtonsEnabled = true;
             result(@([player position]));
         } else if ([@"absolutePosition" isEqualToString:call.method]) {
             result(@([player absolutePosition]));
+        } else if ([@"getDuration" isEqualToString:call.method]) {
+            result(@([player duration]));
         } else if ([@"seekTo" isEqualToString:call.method]) {
             [player seekTo:[argsMap[@"location"] intValue]];
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -512,8 +512,8 @@ bool _isCommandCenterButtonsEnabled = true;
             result(@([player position]));
         } else if ([@"absolutePosition" isEqualToString:call.method]) {
             result(@([player absolutePosition]));
-        } else if ([@"getDuration" isEqualToString:call.method]) {
-            result(@([player duration]));
+        } else if ([@"getDvrDuration" isEqualToString:call.method]) {
+            result(@([player getDvrDuration]));
         } else if ([@"seekTo" isEqualToString:call.method]) {
             [player seekTo:[argsMap[@"location"] intValue]];
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -513,7 +513,7 @@ bool _isCommandCenterButtonsEnabled = true;
         } else if ([@"absolutePosition" isEqualToString:call.method]) {
             result(@([player absolutePosition]));
         } else if ([@"getDvrDuration" isEqualToString:call.method]) {
-            result(@([player getDvrDuration]));
+            result(@([player dvrDuration]));
         } else if ([@"seekTo" isEqualToString:call.method]) {
             [player seekTo:[argsMap[@"location"] intValue]];
 

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1310,6 +1310,10 @@ class BetterPlayerController {
     }
   }
 
+  Future<Duration?>? getDuration() async {
+    return videoPlayerController?.duration;
+  }
+
   ///Clear all cached data. Video player controller must be initialized to
   ///clear the cache.
   Future<void> clearCache() async {

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1310,8 +1310,8 @@ class BetterPlayerController {
     }
   }
 
-  Future<Duration?>? getDuration() async {
-    return videoPlayerController?.duration;
+  Future<Duration?>? getDvrDuration() async {
+    return videoPlayerController?.dvrDuration;
   }
 
   ///Clear all cached data. Video player controller must be initialized to

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -217,10 +217,10 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<Duration> getDuration(int? textureId) async {
+  Future<Duration> getDvrDuration(int? textureId) async {
     return Duration(
         milliseconds: await _channel.invokeMethod<int>(
-              'getDuration',
+              'getDvrDuration',
               <String, dynamic>{'textureId': textureId},
             ) ??
             0);

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -217,6 +217,16 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
+  Future<Duration> getDuration(int? textureId) async {
+    return Duration(
+        milliseconds: await _channel.invokeMethod<int>(
+              'getDuration',
+              <String, dynamic>{'textureId': textureId},
+            ) ??
+            0);
+  }
+
+  @override
   Future<DateTime?> getAbsolutePosition(int? textureId) async {
     final int milliseconds = await _channel.invokeMethod<int>(
           'absolutePosition',

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -532,6 +532,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return _videoPlayerPlatform.getPosition(_textureId);
   }
 
+  /// The duration of the current video.
+  Future<Duration?> get duration async {
+    if (!value.initialized && _isDisposed) {
+      return null;
+    }
+    return _videoPlayerPlatform.getDuration(_textureId);
+  }
+
   /// The absolute position in the current video stream
   /// (i.e. EXT-X-PROGRAM-DATE-TIME in HLS).
   Future<DateTime?> get absolutePosition async {

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -533,11 +533,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   /// The duration of the current video.
-  Future<Duration?> get duration async {
+  Future<Duration?> get dvrDuration async {
     if (!value.initialized && _isDisposed) {
       return null;
     }
-    return _videoPlayerPlatform.getDuration(_textureId);
+    return _videoPlayerPlatform.getDvrDuration(_textureId);
   }
 
   /// The absolute position in the current video stream

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -534,7 +534,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// The duration of the current video.
   Future<Duration?> get dvrDuration async {
-    if (!value.initialized && _isDisposed) {
+    if (!value.initialized && _isDisposed || _textureId == null) {
       return null;
     }
     return _videoPlayerPlatform.getDvrDuration(_textureId);

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -532,7 +532,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     return _videoPlayerPlatform.getPosition(_textureId);
   }
 
-  /// The duration of the current video.
+  /// The duration when playing DVR content.
   Future<Duration?> get dvrDuration async {
     if (!value.initialized && _isDisposed || _textureId == null) {
       return null;

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -133,6 +133,11 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('getPosition() has not been implemented.');
   }
 
+  /// Gets duration of the video.
+  Future<Duration> getDuration(int? textureId) {
+    throw UnimplementedError('getDuration() has not been implemented.');
+  }
+
   /// Gets the video position as [DateTime].
   Future<DateTime?> getAbsolutePosition(int? textureId) {
     throw UnimplementedError('getAbsolutePosition() has not been implemented.');

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -134,8 +134,8 @@ abstract class VideoPlayerPlatform {
   }
 
   /// Gets duration of the video.
-  Future<Duration> getDuration(int? textureId) {
-    throw UnimplementedError('getDuration() has not been implemented.');
+  Future<Duration> getDvrDuration(int? textureId) {
+    throw UnimplementedError('getDvrDuration() has not been implemented.');
   }
 
   /// Gets the video position as [DateTime].

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -133,7 +133,7 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('getPosition() has not been implemented.');
   }
 
-  /// Gets duration of the video.
+  /// Gets duration of the DVR video.
   Future<Duration> getDvrDuration(int? textureId) {
     throw UnimplementedError('getDvrDuration() has not been implemented.');
   }


### PR DESCRIPTION
Add method to get DVR Duration: `getDvrDuration`. 
The method will be called from app side once per one second while playing DVR content.

Ticket:
https://dw-ml-nfc.atlassian.net/browse/DAF-4341

App side modification:
https://github.com/dwango-nfc/dwango-app-ch/pull/1767

*This PR should be merged into main branch after [this PR for PIP impleemntation.](https://github.com/dwango-nfc/betterplayer/pull/32)