### PR TITLE
DAF-4440: Fix limited plan section got leaked if press seek button on PiP while pausing

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -67,9 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIsLiveStream:(BOOL) isLiveStream;
 - (void)setIsDisplayPipButtons:(BOOL) isDisplay;
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay;
-- (void)showBlackCoverView;
+- (void)showBlackCoverViewInPIP;
 - (void)hideBlackCoverView;
-- (void)showLimitedPlanCoverView;
+- (void)showLimitedPlanCoverViewInPiP;
 - (void)hideLimitedPlanCoverView;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -69,8 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay;
 - (void)showBlackCoverViewInPIP;
 - (void)hideBlackCoverView;
-- (void)showLimitedPlanCoverViewInPiP;
-- (void)hideLimitedPlanCoverView;
+- (void)showLimitedPlanCoverViewInPIP;
+- (void)hideLimitedPlanCoverViewInPIP;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;
 

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) float playerRate;
 @property(nonatomic) int overriddenDuration;
 @property(nonatomic) AVPlayerTimeControlStatus lastAvPlayerTimeControlStatus;
+@property(nonatomic) UIView* blackCoverView;
 @property(nonatomic) UIImageView* limitedPlanCoverView;
 @property(nonatomic) bool isPremiumBannerDisplay;
 @property(nonatomic) bool isPipMode;
@@ -66,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIsLiveStream:(BOOL) isLiveStream;
 - (void)setIsDisplayPipButtons:(BOOL) isDisplay;
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay;
+- (void)showBlackCoverView;
+- (void)hideBlackCoverView;
 - (void)showLimitedPlanCoverView;
 - (void)hideLimitedPlanCoverView;
 - (int64_t)absolutePosition;

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) UIImageView* limitedPlanCoverView;
 @property(nonatomic) bool isPremiumBannerDisplay;
 @property(nonatomic) bool isPipMode;
+@property(nonatomic) id timeObserverId;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -805,7 +805,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     [self setIsPipMode:true];
 
     if (_isPremiumBannerDisplay) {
-        [self showLimitedPlanCoverView];
+        [self showLimitedPlanCoverViewInPiP];
     } else {
         [self hideLimitedPlanCoverView];
     }
@@ -876,7 +876,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _blackCoverView.backgroundColor = [UIColor blackColor];
 }
 
-- (void) showBlackCoverView {
+- (void) showBlackCoverViewInPIP {
     UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
     if (window && _isPipMode) {
         [window addSubview:_blackCoverView];
@@ -904,7 +904,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _limitedPlanCoverView.image = image;
 }
 
-- (void) showLimitedPlanCoverView {
+- (void) showLimitedPlanCoverViewInPiP {
     UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
     if (window && _isPipMode) {
         [window addSubview:_limitedPlanCoverView];

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -793,6 +793,11 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         _eventSink(@{@"event" : @"exitingPIP",
                      @"wasPlaying" : @(wasPlaying),
                    });
+        if (!_isPlaying && !_isLiveStream) {
+            _eventSink(@{@"event" : @"seek",
+                         @"position" : @([self position]),
+                       });
+        }
     }
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -792,12 +792,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (_eventSink != nil) {
         _eventSink(@{@"event" : @"exitingPIP",
                      @"wasPlaying" : @(wasPlaying),
+                     @"position" : @([self position]),
                    });
-        if (!_isPlaying && !_isLiveStream) {
-            _eventSink(@{@"event" : @"seek",
-                         @"position" : @([self position]),
-                       });
-        }
     }
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -786,7 +786,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)pictureInPictureControllerWillStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
     [self setIsPipMode:false];
     [self hideBlackCoverView];
-    [self hideLimitedPlanCoverView];
+    [self hideLimitedPlanCoverViewInPIP];
     
     bool wasPlaying = _isPlaying;
     if (_eventSink != nil) {
@@ -805,9 +805,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     [self setIsPipMode:true];
 
     if (_isPremiumBannerDisplay) {
-        [self showLimitedPlanCoverViewInPiP];
+        [self showLimitedPlanCoverViewInPIP];
     } else {
-        [self hideLimitedPlanCoverView];
+        [self hideLimitedPlanCoverViewInPIP];
     }
     
     // When change to PIP mode, need to correct control status
@@ -904,7 +904,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _limitedPlanCoverView.image = image;
 }
 
-- (void) showLimitedPlanCoverViewInPiP {
+- (void) showLimitedPlanCoverViewInPIP {
     UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
     if (window && _isPipMode) {
         [window addSubview:_limitedPlanCoverView];
@@ -917,7 +917,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
 }
 
-- (void) hideLimitedPlanCoverView {
+- (void) hideLimitedPlanCoverViewInPIP {
     if (_limitedPlanCoverView) {
         [_limitedPlanCoverView removeFromSuperview];
     }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -131,7 +131,7 @@ int _seekPosition;
 - (void)notifyPlaybackChangeInPiP {
     int64_t position = [self position];
     
-    if (_isPipMode && !_isLiveStream && position >= 0) {
+    if (_isPipMode && position >= 0) {
         if (_eventSink) {
             _eventSink(@{@"event" : @"playbackStatusChangeInPiP", @"position": @(position)});
         }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -23,6 +23,7 @@ int _seekPosition;
 @implementation BetterPlayer
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super init];
+    [self initBlackCoverView];
     [self initLimitedPlanCoverView];
     NSAssert(self, @"super init cannot be nil");
     _isInitialized = false;
@@ -784,6 +785,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)pictureInPictureControllerWillStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
     [self setIsPipMode:false];
+    [self hideBlackCoverView];
+    [self hideLimitedPlanCoverView];
     
     bool wasPlaying = _isPlaying;
     if (_eventSink != nil) {
@@ -859,6 +862,32 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   } else {
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
   }
+}
+
+- (void) initBlackCoverView {
+    _blackCoverView = NULL;
+    _blackCoverView = [[UIView alloc] init];
+    _blackCoverView.translatesAutoresizingMaskIntoConstraints = false;
+    _blackCoverView.backgroundColor = [UIColor blackColor];
+}
+
+- (void) showBlackCoverView {
+    UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
+    if (window && _isPipMode) {
+        [window addSubview:_blackCoverView];
+        [NSLayoutConstraint activateConstraints:@[
+            [_blackCoverView.topAnchor constraintEqualToAnchor:window.topAnchor],
+            [_blackCoverView.bottomAnchor constraintEqualToAnchor:window.bottomAnchor],
+            [_blackCoverView.leadingAnchor constraintEqualToAnchor:window.leadingAnchor],
+            [_blackCoverView.trailingAnchor constraintEqualToAnchor:window.trailingAnchor],
+        ]];
+    }
+}
+
+- (void) hideBlackCoverView {
+    if (_blackCoverView) {
+        [_blackCoverView removeFromSuperview];
+    }
 }
 
 - (void) initLimitedPlanCoverView {

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -388,6 +388,7 @@ bool _isCommandCenterButtonsEnabled = true;
             [player clear];
             // This call will clear cached frame because we will return transparent frame
             
+            [player showBlackCoverView];
             NSDictionary* dataSource = argsMap[@"dataSource"];
             [_dataSourceDict setObject:dataSource forKey:[self getTextureId:player]];
             NSString* assetArg = dataSource[@"asset"];
@@ -586,6 +587,8 @@ bool _isCommandCenterButtonsEnabled = true;
             }
             result(nil);
         } else if ([@"setIsPremiumBannerDisplay" isEqualToString:call.method]){
+            [player hideBlackCoverView];
+
             BOOL isDisplay = false;
             id isDisplayObject = [argsMap objectForKey:@"isDisplay"];
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -381,6 +381,11 @@ bool _isCommandCenterButtonsEnabled = true;
         [self onPlayerSetup:player result:result];
     } else {
         NSDictionary* argsMap = call.arguments;
+        id textureIdObject = [argsMap objectForKey:@"textureId"];
+        
+        if (textureIdObject == [NSNull null]) {
+            return;
+        }
         int64_t textureId = ((NSNumber*)argsMap[@"textureId"]).unsignedIntegerValue;
         BetterPlayer* player = _players[@(textureId)];
         if ([@"setDataSource" isEqualToString:call.method]) {

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -602,9 +602,9 @@ bool _isCommandCenterButtonsEnabled = true;
                 
                 if (player.isPremiumBannerDisplay != isDisplay) {
                     if (isDisplay) {
-                        [player showLimitedPlanCoverViewInPiP];
+                        [player showLimitedPlanCoverViewInPIP];
                     } else {
-                        [player hideLimitedPlanCoverView];
+                        [player hideLimitedPlanCoverViewInPIP];
                     }
                 }
                 [player setIsPremiumBannerDisplay:isDisplay];

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -393,7 +393,7 @@ bool _isCommandCenterButtonsEnabled = true;
             [player clear];
             // This call will clear cached frame because we will return transparent frame
             
-            [player showBlackCoverView];
+            [player showBlackCoverViewInPIP];
             NSDictionary* dataSource = argsMap[@"dataSource"];
             [_dataSourceDict setObject:dataSource forKey:[self getTextureId:player]];
             NSString* assetArg = dataSource[@"asset"];
@@ -602,7 +602,7 @@ bool _isCommandCenterButtonsEnabled = true;
                 
                 if (player.isPremiumBannerDisplay != isDisplay) {
                     if (isDisplay) {
-                        [player showLimitedPlanCoverView];
+                        [player showLimitedPlanCoverViewInPiP];
                     } else {
                         [player hideLimitedPlanCoverView];
                     }

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -34,4 +34,5 @@ enum BetterPlayerEventType {
   tapExternalPauseButton, // Android only. Fire when tap pause button from outside the app (e.g. PIP, Notification).
   finishedPlayInLooping, // Ios only. Trigger when postion = duration in looping mode,
   pressedBackToAppButton, // Ios only. Trigger when back to app button ( right button in pip mode) was pressed
+  playbackStatusChangeInPiP, // iOS only. Trigger whenever playback jumps or starts or stops in PiP mode.
 }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1211,6 +1211,7 @@ class BetterPlayerController {
           BetterPlayerEventType.exitingPIP,
           parameters: <String, dynamic>{
             _wasPlayingParameter: event.wasPlaying,
+            _progressParameter: event.position,
           },
         ));
         break;

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1232,6 +1232,14 @@ class BetterPlayerController {
         _postEvent(
             BetterPlayerEvent(BetterPlayerEventType.pressedBackToAppButton));
         break;
+      case VideoEventType.playbackStatusChangeInPiP:
+        _postEvent(BetterPlayerEvent(
+          BetterPlayerEventType.playbackStatusChangeInPiP,
+          parameters: <String, dynamic>{
+            _progressParameter: event.position,
+          },
+        ));
+        break;
 
       default:
 

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -457,6 +457,7 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             eventType: VideoEventType.exitingPIP,
             key: key,
             wasPlaying: map['wasPlaying'] as bool?,
+            position: Duration(milliseconds: map['position'] as int),
           );
 
         case 'tapExternalPlayButton':

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -483,6 +483,13 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             key: key,
           );
 
+        case 'playbackStatusChangeInPiP':
+          return VideoEvent(
+            eventType: VideoEventType.playbackStatusChangeInPiP,
+            position: Duration(milliseconds: map['position'] as int),
+            key: key,
+          );
+
         default:
           return VideoEvent(
             eventType: VideoEventType.unknown,

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -515,6 +515,9 @@ enum VideoEventType {
 
   /// back to app button ( right button in pip mode) was pressed (iOS only)
   pressedBackToAppButton,
+
+  /// iOS only. Trigger whenever playback jumps or starts or stops in PiP mode.
+  playbackStatusChangeInPiP,
 }
 
 /// Describes a discrete segment of time within a video using a [start] and


### PR DESCRIPTION
## Description
The bugs in this PR have already existed before the refactoring. And we decide to fix them in this PR as a part of the refactoring.

- [app side implement](https://github.com/dwango-nfc/dwango-app-ch/pull/1811)

### Problem
We couldn't listen for the "press seek button on PiP" event, and the flutter app side never knew about the changed playback if we pressed that button.
So the app side couldn't handle the premium banner accurately because it still keep the old position.

### What was done (Please be a little bit specific)
- Fix limited plan section got leaked if press `seek` button on PiP while pausing [9be506f](https://github.com/dwango-nfc/betterplayer/commit/9be506f8fe06330cba91eb7d61e87d3ffb7c6034) ([Related app side commit](https://github.com/dwango-nfc/dwango-app-ch/commit/cd5c313a3bdeaac0638d4e61d840de2bfe946302))
- Re-add `BlackCoverView` to fix limited plan section got leaked on auto next video [d2fade5](https://github.com/dwango-nfc/betterplayer/commit/d2fade527ba6e1c12b761481ebdaddcc501ec480) 
- Fix `position` did not update when return to detail screen after pressing PiP `seek` button while still pausing [09f57fc](https://github.com/dwango-nfc/betterplayer/commit/09f57fcc753a33c2606cf604a0b81b6caac89856) 
- Fix app crash when user watch `LIVE` content [8af9988](https://github.com/dwango-nfc/betterplayer/commit/8af9988763d9205e81aa83c72d508517b323d7b7) ([Related app side commit](https://github.com/dwango-nfc/dwango-app-ch/commit/aca7f7191a4637a66e0e2742003b8a0fbb66d3a5))

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4440

## Screenshot

*paid part start from `2:17`.

https://github.com/dwango-nfc/dwango-app-ch/assets/100773699/1541c9bc-bd3e-4ed0-945d-736eaeaa2029
