### PR TITLE
DAF-4469: Fix didn't hide PIP seek buttons while watching DVR

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -65,6 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)disablePictureInPicture;
 - (void)willStartPictureInPicture:(bool)willStart;
 - (void)setIsLiveStream:(BOOL) isLiveStream;
+- (void)setPipSeekButtonsHidden:(BOOL) isHidden;
 - (void)setIsDisplayPipButtons:(BOOL) isDisplay;
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay;
 - (void)showBlackCoverViewInPIP;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -706,6 +706,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
                 _pipController.canStartPictureInPictureAutomaticallyFromInline = true;
             }
             _pipController.delegate = self;
+            [self setPipSeekButtonsHidden:_isLiveStream];
         }
     } else {
         // Fallback on earlier versions
@@ -826,6 +827,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setIsLiveStream:(BOOL) isLiveStream {
     _isLiveStream = isLiveStream;
+}
+
+- (void)setPipSeekButtonsHidden:(BOOL) isHidden {
+    _pipController.requiresLinearPlayback = isHidden;
 }
 
 - (void)setIsDisplayPipButtons:(BOOL) isDisplay {

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -409,6 +409,7 @@ bool _isCommandCenterButtonsEnabled = true;
             [self disposeNotificationData:player];
             
             BOOL isLiveStream = [self isLiveStream:player];
+            [player setPipSeekButtonsHidden:isLiveStream];
             [player setIsLiveStream:isLiveStream];
 
             int overriddenDuration = 0;


### PR DESCRIPTION
## Description

This bug occurs after remove `setPipSeekButtonsHidden` handlers on #53 

### What was done (Please be a little bit specific)

- revert [2dd5e73...](https://github.com/dwango-nfc/betterplayer/pull/53/commits/2dd5e73811500e378341727669add74e13cfe7aa) (remove setPipSeekButtonsHidden logics of limited plan video)

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4469
