### PR TITLE
DAF-4477: Fix limited plan frame got leaked after seeking while paused then press Play

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -131,7 +131,7 @@ int _seekPosition;
 - (void)notifyPlaybackChangeInPiP {
     int64_t position = [self position];
     
-    if (_isPipMode && position >= 0) {
+    if (_isPipMode && !_isLiveStream && position >= 0) {
         if (_eventSink) {
             _eventSink(@{@"event" : @"playbackStatusChangeInPiP", @"position": @(position)});
         }

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -75,7 +75,7 @@ int _seekPosition;
         
         // use CMTimeMake(1000000, 1) to only invoking the block whenever time jumps or playback starts or stops. (Doc: https://developer.apple.com/documentation/avfoundation/avplayer/1385829-addperiodictimeobserverforinterv#discussion)
         _timeObserverId = [_player addPeriodicTimeObserverForInterval:CMTimeMake(1000000, 1) queue:NULL usingBlock:^(CMTime time){
-           [self notifyPlaybackChangeInPiP];
+           [self notifyPlaybackChangeInPIPforVOD];
         }];
         self._observersAdded = true;
     }
@@ -128,12 +128,12 @@ int _seekPosition;
     }
 }
 
-- (void)notifyPlaybackChangeInPiP {
+- (void)notifyPlaybackChangeInPIPforVOD {
     int64_t position = [self position];
     
     if (_isPipMode && !_isLiveStream && position >= 0) {
         if (_eventSink) {
-            _eventSink(@{@"event" : @"playbackStatusChangeInPiP", @"position": @(position)});
+            _eventSink(@{@"event" : @"playbackStatusChangeInPIPforVOD", @"position": @(position)});
         }
     }
 }

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -34,5 +34,5 @@ enum BetterPlayerEventType {
   tapExternalPauseButton, // Android only. Fire when tap pause button from outside the app (e.g. PIP, Notification).
   finishedPlayInLooping, // Ios only. Trigger when postion = duration in looping mode,
   pressedBackToAppButton, // Ios only. Trigger when back to app button ( right button in pip mode) was pressed
-  playbackStatusChangeInPiP, // iOS only. Trigger whenever playback jumps or starts or stops in PiP mode.
+  playbackStatusChangeInPIPforVOD, // iOS only. VOD only. Trigger whenever playback jumps or starts or stops in PiP mode.
 }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1233,9 +1233,9 @@ class BetterPlayerController {
         _postEvent(
             BetterPlayerEvent(BetterPlayerEventType.pressedBackToAppButton));
         break;
-      case VideoEventType.playbackStatusChangeInPiP:
+      case VideoEventType.playbackStatusChangeInPIPforVOD:
         _postEvent(BetterPlayerEvent(
-          BetterPlayerEventType.playbackStatusChangeInPiP,
+          BetterPlayerEventType.playbackStatusChangeInPIPforVOD,
           parameters: <String, dynamic>{
             _progressParameter: event.position,
           },

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -484,9 +484,9 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             key: key,
           );
 
-        case 'playbackStatusChangeInPiP':
+        case 'playbackStatusChangeInPIPforVOD':
           return VideoEvent(
-            eventType: VideoEventType.playbackStatusChangeInPiP,
+            eventType: VideoEventType.playbackStatusChangeInPIPforVOD,
             position: Duration(milliseconds: map['position'] as int),
             key: key,
           );

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -257,6 +257,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           break;
         case VideoEventType.exitingPIP:
           break;
+        case VideoEventType.playbackStatusChangeInPIPforVOD:
+          value = value.copyWith(position: event.position);
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -516,8 +516,8 @@ enum VideoEventType {
   /// back to app button ( right button in pip mode) was pressed (iOS only)
   pressedBackToAppButton,
 
-  /// iOS only. Trigger whenever playback jumps or starts or stops in PiP mode.
-  playbackStatusChangeInPiP,
+  /// iOS only. VOD only. Trigger whenever playback jumps or starts or stops in PiP mode.
+  playbackStatusChangeInPIPforVOD,
 }
 
 /// Describes a discrete segment of time within a video using a [start] and


### PR DESCRIPTION
## Description

- [app side implement](https://github.com/dwango-nfc/dwango-app-ch/pull/1830)

### Problem
In the flutter side, the `VideoPlayerController.value` wouldn't update if the playback got changed in PIP while pausing.
If we press the Play button after that, it will jump in to `progress` event and handle premium banner with that old `value` then the limited plan section got leaked in very short of time.

### What was done (Please be a little bit specific)
- update `VideoPlayerController.value` whenever playback got changed in PIP.
- Check `isLivestream` in native side because both app flutter side and better_player flutter side are listening to `playbackStatusChangeInPIPforVOD` event now.
- Remove `isLive` check in the app side.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4477

## Screenshot

https://github.com/dwango-nfc/betterplayer/assets/100773699/f2380106-ad83-4c2b-9f4c-9bcaa873aa6e


