### PR TITLE
DAF-4484: Fix limited plan frame got leaked after returning to landscape mode from PIP mode

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -935,14 +935,15 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 ///     - Hide LimitedPlanCoverView.
 - (void)hideLimitedPlanCoverAfterPipCompletelyGone {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (_isPipMode == false && [_pipController isPictureInPictureActive]) {
+        if (_isPipMode) {
+            return;
+        }
+        if ([_pipController isPictureInPictureActive]) {
             [self hideLimitedPlanCoverAfterPipCompletelyGone];
             return;
         }
         
-        if (_isPipMode == false) {
-            [self hideLimitedPlanCoverViewInPIP];
-        }
+        [self hideLimitedPlanCoverViewInPIP];
     });
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -935,12 +935,12 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 ///     - Hide LimitedPlanCoverView.
 - (void)hideLimitedPlanCoverAfterPipCompletelyGone {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if(_isPipMode == false && [_pipController isPictureInPictureActive]){
+        if (_isPipMode == false && [_pipController isPictureInPictureActive]) {
             [self hideLimitedPlanCoverAfterPipCompletelyGone];
             return;
         }
         
-        if(_isPipMode == false){
+        if (_isPipMode == false) {
             [self hideLimitedPlanCoverViewInPIP];
         }
     });

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -787,7 +787,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)pictureInPictureControllerWillStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
     [self setIsPipMode:false];
     [self hideBlackCoverView];
-    [self hideLimitedPlanCoverViewInPIP];
+    [self hideLimitedPlanCoverAfterPipCompletelyGone];
     
     bool wasPlaying = _isPlaying;
     if (_eventSink != nil) {
@@ -922,6 +922,28 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (_limitedPlanCoverView) {
         [_limitedPlanCoverView removeFromSuperview];
     }
+}
+
+/// Hide LimitedPlanCoverView after the PIP is completely gone.
+///
+/// - if _isPipMode == true and isPictureInPictureActive is whatever (still in PIP mode)
+///     - All the check is false, finish this function without any actions.
+///     - The showLimitedPlanCoverView logics already handled when re-entering PIP and while in PIP mode.
+/// - if _isPipMode == false and isPictureInPictureActive == true (while exiting PIP, and not completed yet)
+///     - Call the loop and re-checking after 0.1 seconds.
+/// - if _isPipMode == false and isPictureInPictureActive == false (the PIP is completely gone)
+///     - Hide LimitedPlanCoverView.
+- (void)hideLimitedPlanCoverAfterPipCompletelyGone {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if(_isPipMode == false && [_pipController isPictureInPictureActive]){
+            [self hideLimitedPlanCoverAfterPipCompletelyGone];
+            return;
+        }
+        
+        if(_isPipMode == false){
+            [self hideLimitedPlanCoverViewInPIP];
+        }
+    });
 }
 
 - (void) setIsPipMode:(bool)isPipMode {


### PR DESCRIPTION
## Description

### Problem
The `DidStopPictureInPicture` is never got called, and the time period from the `WillStopPictureInPicture` got called to the time PIP is completely gone in the low performance devices is long enough to see one frame of limited plan got leaked. (in iPhone 13 mini, that time period is ~0,02s for portrait mode, and ~0,04s for landscape mode).

### What was done (Please be a little bit specific)

- Make a loop to check whenever the PIP completely gone then hide the `LimitedPlanCoverView`.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4484

## Screenshot or Video (Before/After)

- Before:

https://github.com/dwango-nfc/betterplayer/assets/100773699/48fa35bd-2913-442a-8495-dfad64d73c2b

- After:

https://github.com/dwango-nfc/betterplayer/assets/100773699/ecda6b4f-5be0-4ebc-82ee-bd4393f4c5fd


