### PR TITLE
DAF-4657: Leak image of Paid part when switching between landscape mode and normal mode by rotating the screen 

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -72,6 +72,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideBlackCoverView;
 - (void)showLimitedPlanCoverViewInPIP;
 - (void)hideLimitedPlanCoverViewInPIP;
+- (void)showLimitedBlackCoverView;
+- (void)hideLimitedBlackCoverView;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -846,6 +846,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
+    if (self._betterPlayerView.subviews.contains(_limitedBlackCoverView)) return;
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
         [NSLayoutConstraint activateConstraints:@[
             [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
@@ -863,11 +864,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay {
     _isPremiumBannerDisplay = isDisplay;
-    if (isDisplay) {
-        [self showLimitedBlackCoverView];
-    } else {
-        [self hideLimitedBlackCoverView];
-    }
 }
 
 - (void) setAudioTrack:(NSString*) name index:(int) index{

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -839,6 +839,17 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay {
     _isPremiumBannerDisplay = isDisplay;
+    if (isDisplay) {
+        [self._betterPlayerView addSubview:_blackCoverView];
+        [NSLayoutConstraint activateConstraints:@[
+            [_blackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
+            [_blackCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
+            [_blackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
+            [_blackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
+        ]];
+    } else if (_blackCoverView) {
+        [_blackCoverView removeFromSuperview];
+    }
 }
 
 - (void) setAudioTrack:(NSString*) name index:(int) index{

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -25,6 +25,7 @@ int _seekPosition;
     self = [super init];
     [self initBlackCoverView];
     [self initLimitedPlanCoverView];
+    [self initLimitedBlackCoverView];
     NSAssert(self, @"super init cannot be nil");
     _isInitialized = false;
     _isPlaying = false;
@@ -837,18 +838,35 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     [_pipController setValue:[NSNumber numberWithInt:isDisplay ? 0 : 1] forKey:@"controlsStyle"];
 }
 
+- (void) initLimitedBlackCoverView {
+    _limitedBlackCoverView = NULL;
+    _limitedBlackCoverView = [[UIView alloc] init];
+    _limitedBlackCoverView.translatesAutoresizingMaskIntoConstraints = false;
+    _limitedBlackCoverView.backgroundColor = [UIColor blackColor];
+}
+
+- (void) showLimitedBlackCoverView {
+    [self._betterPlayerView addSubview:_limitedBlackCoverView];
+        [NSLayoutConstraint activateConstraints:@[
+            [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
+            [_limitedBlackCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
+            [_limitedBlackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
+            [_limitedBlackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
+        ]];
+}
+
+- (void) hideLimitedBlackCoverView {
+    if (_limitedBlackCoverView) {
+        [_limitedBlackCoverView removeFromSuperview];
+    }
+}
+
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay {
     _isPremiumBannerDisplay = isDisplay;
     if (isDisplay) {
-        [self._betterPlayerView addSubview:_blackCoverView];
-        [NSLayoutConstraint activateConstraints:@[
-            [_blackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
-            [_blackCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
-            [_blackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
-            [_blackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
-        ]];
-    } else if (_blackCoverView) {
-        [_blackCoverView removeFromSuperview];
+        [self showLimitedBlackCoverView];
+    } else {
+        [self hideLimitedBlackCoverView];
     }
 }
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -604,8 +604,10 @@ bool _isCommandCenterButtonsEnabled = true;
                 if (player.isPremiumBannerDisplay != isDisplay) {
                     if (isDisplay) {
                         [player showLimitedPlanCoverViewInPIP];
+                        [player showLimitedBlackCoverView];
                     } else {
                         [player hideLimitedPlanCoverViewInPIP];
+                        [player hideLimitedBlackCoverView];
                     }
                 }
                 [player setIsPremiumBannerDisplay:isDisplay];


### PR DESCRIPTION
## Description
### Problem
Leak image of Paid part when switching between landscape mode and normal mode by rotating the screen
- After update flutter version to 3.13.9, the function `didChangeMetrics` triggers slowly so the logic handle hide player view is delayed -> leak video frame
### Solution
Handle logic hide player view directly when call `betterPlayerController.setIsPremiumBannerDisplay`

### What was done (Please be a little bit specific)

- Handle logic hide player view directly when call `betterPlayerController.setIsPremiumBannerDisplay`

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4657

### JP (and VN) Specs
None

### Figma
None

### API (Only for API implementation)
None

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [x] Builds and runs on Android (No new warnings nor new errors)
