### PR TITLE
DAF 4657: Leak image of Paid part when switching between landscape mode and normal mode by rotating the screen

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) AVPlayerTimeControlStatus lastAvPlayerTimeControlStatus;
 @property(nonatomic) UIView* blackCoverView;
 @property(nonatomic) UIImageView* limitedPlanCoverView;
+@property(nonatomic) UIView* limitedBlackCoverView;
 @property(nonatomic) bool isPremiumBannerDisplay;
 @property(nonatomic) bool isPipMode;
 @property(nonatomic) id timeObserverId;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -846,7 +846,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
-    if (self._betterPlayerView.subviews.contains(_limitedBlackCoverView)) return;
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
         [NSLayoutConstraint activateConstraints:@[
             [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],


### PR DESCRIPTION
## Description
### Problem
Leak image of Paid part when switching between landscape mode and normal mode by rotating the screen
- After update flutter version to 3.13.9, the function `didChangeMetrics` triggers slowly so the logic handle hide player view is delayed -> leak video frame
### Solution
Handle logic hide player view directly when call `betterPlayerController.setIsPremiumBannerDisplay`

### What was done (Please be a little bit specific)

- Handle logic hide player view directly when call `betterPlayerController.setIsPremiumBannerDisplay`

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4657

### JP (and VN) Specs
None

### Figma
None

### API (Only for API implementation)
None

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)
I added video in here: https://github.com/dwango-nfc/dwango-app-ch/pull/1897
## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [x] Builds and runs on Android (No new warnings nor new errors)
