### PR TITLE
[Hot fix] DAF-4734: When opening the archive of a livestream limited to members on the viewing app, the viewing app crashes

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -846,6 +846,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
+    if (self._betterPlayerView == nil) {
+        return;
+    }
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
         [NSLayoutConstraint activateConstraints:@[
             [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],


### PR DESCRIPTION
## Description
### Problem
Because in case **Full premium video**,  _betterPlayerView is not initialized, so app crash in here: https://github.com/dwango-nfc/betterplayer/blob/cf22446ffc59aee95643978311aac68d47582b4d/ios/Classes/BetterPlayer.m#L849
### Solution
- Check nil before addSubView
- I checked the related cases and they all work fine
### What was done (Please be a little bit specific)
Check nil before addSubView
## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4734

### JP (and VN) Specs
None

### Figma
None

### API (Only for API implementation)
None

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)
Before

https://github.com/dwango-nfc/betterplayer/assets/79908230/6561f20c-cdf9-4500-94cb-db67927c2cd2

After

https://github.com/dwango-nfc/betterplayer/assets/79908230/45cc2a0d-5bfc-4292-9006-1c90c6febecb



## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [x] Builds and runs on Android (No new warnings nor new errors)
