### PR TITLE
DAF-4690: Fix leak plan's video frame when rotating device

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -846,16 +846,18 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
-    if (self._betterPlayerView == nil) {
+    if (self._betterPlayerView == nil || _limitedBlackCoverView.superview != nil) {
         return;
     }
+
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
-        [NSLayoutConstraint activateConstraints:@[
-            [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
-            [_limitedBlackCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
-            [_limitedBlackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
-            [_limitedBlackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
-        ]];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
+        [_limitedBlackCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
+        [_limitedBlackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
+        [_limitedBlackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
+    ]];
 }
 
 - (void) hideLimitedBlackCoverView {
@@ -934,7 +936,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void) showLimitedPlanCoverViewInPIP {
     UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
-    if (window && _isPipMode) {
+    if (window && _isPipMode && _limitedPlanCoverView.superview == nil) {
         [window addSubview:_limitedPlanCoverView];
         [NSLayoutConstraint activateConstraints:@[
            [_limitedPlanCoverView.topAnchor constraintEqualToAnchor:window.topAnchor],

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -600,16 +600,15 @@ bool _isCommandCenterButtonsEnabled = true;
 
             if (isDisplayObject != [NSNull null]) {
                 isDisplay = [[argsMap objectForKey:@"isDisplay"] boolValue];
-                
-                if (player.isPremiumBannerDisplay != isDisplay) {
-                    if (isDisplay) {
-                        [player showLimitedPlanCoverViewInPIP];
-                        [player showLimitedBlackCoverView];
-                    } else {
-                        [player hideLimitedPlanCoverViewInPIP];
-                        [player hideLimitedBlackCoverView];
-                    }
+
+                if (isDisplay) {
+                    [player showLimitedPlanCoverViewInPIP];
+                    [player showLimitedBlackCoverView];
+                } else {
+                    [player hideLimitedPlanCoverViewInPIP];
+                    [player hideLimitedBlackCoverView];
                 }
+
                 [player setIsPremiumBannerDisplay:isDisplay];
             }
         } else {


### PR DESCRIPTION
## Description

### Problem

- Plan's video frame was leaked when rotating device

Reason:
The `self._betterPlayerView = playerView;` is trigger after adding cover view and seems the parent view of cover view is removed 

https://github.com/dwango-nfc/betterplayer/blob/a534b15727a14d1060d7c86267d551dc34eaac7f/ios/Classes/BetterPlayer.m#L43-L48


### Solution
- Check to add cover view continuously
- Add condition to only add cover view if needed 

### What was done (Please be a little bit specific)
- Remove condition `if (player.isPremiumBannerDisplay != isDisplay) {` to add cover view continuously
- Add condition to only add cover view if needed (prevent to add multi times)

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4690

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)

- updated video at: https://github.com/dwango-nfc/dwango-app-ch/pull/1912

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [x] Includes code refactoring? If yes, the following sub checks are required.
    - [x] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [ ] Builds and runs on Android (No new warnings nor new errors)
