### PR TITLE
DAF-4747: When exiting PIP mode, leak image of Paid part when switching between landscape mode and normal mode by rotating the screen

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -846,11 +846,19 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
-    if (self._betterPlayerView == nil || _limitedBlackCoverView.superview != nil) {
+    if (self._betterPlayerView == nil) {
         return;
     }
 
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
+
+    NSArray *commonConstraints = [self._betterPlayerView.constraints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSLayoutConstraint *constraint, NSDictionary *bindings) {
+        return [constraint.secondItem isEqual:_limitedBlackCoverView] || [constraint.firstItem isEqual:_limitedBlackCoverView];
+    }]];
+
+    if (commonConstraints.count > 0) {
+        return;
+    }
 
     [NSLayoutConstraint activateConstraints:@[
         [_limitedBlackCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -944,8 +944,17 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void) showLimitedPlanCoverViewInPIP {
     UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
-    if (window && _isPipMode && _limitedPlanCoverView.superview == nil) {
+    if (window && _isPipMode) {
         [window addSubview:_limitedPlanCoverView];
+
+        NSArray *commonConstraints = [window.constraints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSLayoutConstraint *constraint, NSDictionary *bindings) {
+            return [constraint.secondItem isEqual:_limitedPlanCoverView] || [constraint.firstItem isEqual:_limitedPlanCoverView];
+        }]];
+
+        if (commonConstraints.count > 0) {
+            return;
+        }
+
         [NSLayoutConstraint activateConstraints:@[
            [_limitedPlanCoverView.topAnchor constraintEqualToAnchor:window.topAnchor],
            [_limitedPlanCoverView.bottomAnchor constraintEqualToAnchor:window.bottomAnchor],

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -852,11 +852,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
     [self._betterPlayerView addSubview:_limitedBlackCoverView];
 
-    NSArray *commonConstraints = [self._betterPlayerView.constraints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSLayoutConstraint *constraint, NSDictionary *bindings) {
-        return [constraint.secondItem isEqual:_limitedBlackCoverView] || [constraint.firstItem isEqual:_limitedBlackCoverView];
-    }]];
-
-    if (commonConstraints.count > 0) {
+    if ([self hasCommonConstraintsBetweenTwoViews:self._betterPlayerView andView2:_limitedBlackCoverView]) {
         return;
     }
 
@@ -866,6 +862,14 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         [_limitedBlackCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
         [_limitedBlackCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
     ]];
+}
+
+- (BOOL)hasCommonConstraintsBetweenTwoViews:(UIView *)view1 andView2:(UIView *)view2 {
+    NSArray *commonConstraints = [view1.constraints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSLayoutConstraint *constraint, NSDictionary *bindings) {
+        return [constraint.firstItem isEqual:view2] || [constraint.secondItem isEqual:view2];
+    }]];
+
+    return commonConstraints.count > 0;
 }
 
 - (void) hideLimitedBlackCoverView {
@@ -947,11 +951,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (window && _isPipMode) {
         [window addSubview:_limitedPlanCoverView];
 
-        NSArray *commonConstraints = [window.constraints filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSLayoutConstraint *constraint, NSDictionary *bindings) {
-            return [constraint.secondItem isEqual:_limitedPlanCoverView] || [constraint.firstItem isEqual:_limitedPlanCoverView];
-        }]];
-
-        if (commonConstraints.count > 0) {
+        if ([self hasCommonConstraintsBetweenTwoViews:window andView2:_limitedPlanCoverView]) {
             return;
         }
 


### PR DESCRIPTION
## Description

### Problem

- Even though we checked to see if the view was added and got the correct answer and call `return` in [this line](https://github.com/dwango-nfc/betterplayer/blob/a534b15727a14d1060d7c86267d551dc34eaac7f/ios/Classes/BetterPlayer.m#L849C19-L849C19), the view has been added but is not displayed. Plan's video frame was leaked when rotating device after back to app from PIP mode
- This problem https://dw-ml-nfc.atlassian.net/browse/DAF-4747?focusedCommentId=129028 handled in [ch-app](https://github.com/dwango-nfc/dwango-app-ch/pull/1944).

### Solution
- Add `BlackLimitedView` continuously by removing the condition `_limitedBlackCoverView.superview != nil` in [here](https://github.com/dwango-nfc/betterplayer/blob/a534b15727a14d1060d7c86267d551dc34eaac7f/ios/Classes/BetterPlayer.m#L849C19-L849C19). The iOS `addSubview` function checks whether a view has been added or not, so we don't need to worry about that. However, we need to check the condition to see if constraints have been added or not. If so, there is no need to add any more.

### What was done (Please be a little bit specific)
- Remove condition `_limitedBlackCoverView.superview != nil` to add `BlackLimitedView` continuously
- Add condition to only add constrains if needed (prevent to add multi times)
- Tested cases:
  - watch live
  - watch live -> pip -> watch live
  - watch live -> mini -> watch live
  - watch live -> DVR 
  - watch live -> DVR -> PIP -> watch live
  - watch live -> DVR -> mini -> watch DVR
  - watch live -> DVR -> watch live
  - watch live -> DVR -> watch live -> PIP -> watch live
  - watch live -> DVR -> watch live -> mini -> watch live
  - watch video
  - watch video -> pip -> watch video
  - watch video -> mini -> watch video

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4747

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)

- updated video at: dwango-app-ch

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [ ] Builds and runs on Android (No new warnings nor new errors)
