### PR TITLE
DAF-5047: Fix crash app when switching video with Ads on 3rd switching

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
@@ -648,6 +648,7 @@ internal class BetterPlayer(
         bitmap: Bitmap? = null,
         isLiveOrMakingArchive: Boolean = true,
     ): MediaSessionCompat? {
+        deactivateMediaSession()
         mediaSession?.release()
         context?.let {
 
@@ -754,6 +755,7 @@ internal class BetterPlayer(
 
     fun disposeMediaSession() {
         if (mediaSession != null) {
+            deactivateMediaSession()
             mediaSession?.release()
         }
         mediaSession = null


### PR DESCRIPTION
## Description
- Relate to https://github.com/dwango-nfc/dwango-app-ch/pull/2234#pullrequestreview-2204563651

### Problem
The app crashed when switching video with Ads on `3rd` switching:

- Play 1st video -> Play Ad -> Playing content  
- Play Next 2nd video  -> Play Ad -> Playing content  
- Play Next 3rd video -> Play Ad -> Start Play content -> `Crashed`

Error Logs:

```
E/AndroidRuntime(13431): FATAL EXCEPTION: main
E/AndroidRuntime(13431): Process: jp.dwango.fca.predev, PID: 13431
E/AndroidRuntime(13431): java.lang.NullPointerException: Attempt to invoke virtual method 'long android.support.v4.media.session.PlaybackStateCompat.getActiveQueueItemId()' on a null object reference
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector$DefaultMediaMetadataProvider.getMetadata(MediaSessionConnector.java:1052)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector.invalidateMediaSessionMetadata(MediaSessionConnector.java:747)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.ext.mediasession.MediaSessionConnector$ComponentListener.onEvents(MediaSessionConnector.java:1180)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.ExoPlayerImpl.lambda$new$0$com-google-android-exoplayer2-ExoPlayerImpl(ExoPlayerImpl.java:266)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.ExoPlayerImpl$$ExternalSyntheticLambda19.invoke(Unknown Source:4)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.util.ListenerSet$ListenerHolder.iterationFinished(ListenerSet.java:341)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.util.ListenerSet.handleMessage(ListenerSet.java:285)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.util.ListenerSet.$r8$lambda$eEvjP-IE0x3J2lRvKfFbbjRFRvc(Unknown Source:0)
E/AndroidRuntime(13431): 	at com.google.android.exoplayer2.util.ListenerSet$$ExternalSyntheticLambda0.handleMessage(Unknown Source:2)
E/AndroidRuntime(13431): 	at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(13431): 	at android.os.Looper.loopOnce(Looper.java:201)
E/AndroidRuntime(13431): 	at android.os.Looper.loop(Looper.java:288)
E/AndroidRuntime(13431): 	at android.app.ActivityThread.main(ActivityThread.java:7870)
E/AndroidRuntime(13431): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(13431): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
E/AndroidRuntime(13431): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
I/Process (13431): Sending signal. PID: 13431 SIG: 9
Lost connection to device.
```

Reason:
- The `MediaSession` is released on `SetupDatasource`.
- The `ExoPlayer` triggers an event on `MediaSessionConnector`
- `MediaSessionConnector` makes a `NullPointerException` because the `MediaSession` is released.

### Solution + what was done
- Un-assignee the player from `MediaSessionConnector` when the `MediaSession` is released.

## Reference
### JIRA

https://dw-ml-nfc.atlassian.net/browse/DAF-5047
