### PR TITLE
DAF-5354: [Android 14-15] Stop/play at PIP doesn't work

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -897,7 +897,9 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val STOP_PRE_CACHE_METHOD = "stopPreCache"
         private val PIP_ASPECT_RATIO = Rational(16, 9)
         const val IS_LIVE_STREAM = "isLiveStream"
-        private val RECEIVER_NOT_EXPORTED = 4
+
+        // https://developer.android.com/reference/androidx/core/content/ContextCompat#RECEIVER_NOT_EXPORTED()
+        private const val RECEIVER_NOT_EXPORTED = 4
 
         /** For custom action from outside the app */
         const val DW_NFC_BETTER_PLAYER_CUSTOM_ACTION =

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -156,7 +156,8 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
     private fun registerBroadcastReceiverForExternalAction() {
         this.activity?.registerReceiver(
             broadcastReceiverForExternalAction,
-            IntentFilter(DW_NFC_BETTER_PLAYER_CUSTOM_ACTION)
+            IntentFilter(DW_NFC_BETTER_PLAYER_CUSTOM_ACTION),
+            RECEIVER_NOT_EXPORTED
         )
     }
 
@@ -244,7 +245,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             Intent(DW_NFC_BETTER_PLAYER_CUSTOM_ACTION).putExtra(
                 EXTRA_ACTION_TYPE,
                 customAction.rawValue
-            ),
+            ).setPackage(activity!!.packageName),
             PendingIntent.FLAG_IMMUTABLE
         )
     }
@@ -896,6 +897,7 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val STOP_PRE_CACHE_METHOD = "stopPreCache"
         private val PIP_ASPECT_RATIO = Rational(16, 9)
         const val IS_LIVE_STREAM = "isLiveStream"
+        private val RECEIVER_NOT_EXPORTED = 4
 
         /** For custom action from outside the app */
         const val DW_NFC_BETTER_PLAYER_CUSTOM_ACTION =

--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayerPlugin.kt
@@ -242,10 +242,9 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         return PendingIntent.getBroadcast(
             flutterState?.applicationContext,
             customAction.rawValue,
-            Intent(DW_NFC_BETTER_PLAYER_CUSTOM_ACTION).putExtra(
-                EXTRA_ACTION_TYPE,
-                customAction.rawValue
-            ).setPackage(activity!!.packageName),
+            Intent(DW_NFC_BETTER_PLAYER_CUSTOM_ACTION)
+                .putExtra(EXTRA_ACTION_TYPE, customAction.rawValue)
+                .setPackage(activity!!.packageName),
             PendingIntent.FLAG_IMMUTABLE
         )
     }


### PR DESCRIPTION
## Description
### Problem
In android 14 and up, because PendingIntent doesn't work and can't get return information in `onReceive()`, RemoteAction doesn't work when user presses button above PIP.

### Solution
- Use `setPackage()` to set packageName for PendingIntent.
- Add RECEIVER_NOT_EXPORTED flags for `registerReceiver()`
- Ref: 
  - https://issuetracker.google.com/issues/293487554#comment14
  - https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
- I tested on all Android versions from Android 11 onwards.
### What was done (Please be a little bit specific)
- Use `setPackage()` to set packageName for PendingIntent.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5354

## Screenshot or Video (Before/After)
Added later in PR on the dwango-app-ch repo.

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [ ] Builds and runs on iOS (No new warnings nor new errors)
- [x] Builds and runs on Android (No new warnings nor new errors)
