### PR TITLE
DAF-5432: change logic init _pipController

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -76,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)hideLimitedPlanCoverViewInPIP;
 - (void)showLimitedBlackCoverView;
 - (void)hideLimitedBlackCoverView;
+- (void)resetPipController;
 - (int64_t)absolutePosition;
 - (int64_t) FLTCMTimeToMillis:(CMTime) time;
 

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -44,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) bool isPremiumBannerDisplay;
 @property(nonatomic) bool isPipMode;
 @property(nonatomic) id timeObserverId;
+@property(nonatomic) UIView* pipBackgroundCoverView;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;

--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -41,10 +41,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) UIView* blackCoverView;
 @property(nonatomic) UIImageView* limitedPlanCoverView;
 @property(nonatomic) UIView* limitedBlackCoverView;
+@property(nonatomic) UIView* pipPlayerPlaceholderView;
 @property(nonatomic) bool isPremiumBannerDisplay;
 @property(nonatomic) bool isPipMode;
 @property(nonatomic) id timeObserverId;
-@property(nonatomic) UIView* pipBackgroundCoverView;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -45,15 +45,6 @@ int _seekPosition;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
-
-    if (_pipController) {
-        AVPlayerLayer *playerLayer = playerView.playerLayer;
-        if (playerLayer) {
-            _pipController.contentSource = [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:playerLayer];
-            _pipController.canStartPictureInPictureAutomaticallyFromInline = false;
-        }
-    }
-
     return playerView;
 }
 
@@ -712,8 +703,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
         AVPlayerLayer *playerLayer = self._betterPlayerView.playerLayer;
         if (!_pipController && playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
-            AVPictureInPictureControllerContentSource *contentSource = [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:playerLayer];
-            _pipController = [[AVPictureInPictureController alloc] initWithContentSource: contentSource];
+            _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer: playerLayer];
             if (@available(iOS 14.2, *)) {
                 _pipController.canStartPictureInPictureAutomaticallyFromInline = true;
             }
@@ -925,6 +915,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)resetPipController {
+    // use `playerLayer` from `_player` instead of `_pipController.contentSource.playerLayer` to reset `pipController`.
     AVPlayerLayer *playerLayer = [AVPlayerLayer playerLayerWithPlayer:_player];
     if (!playerLayer) {
         return;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -26,6 +26,7 @@ int _seekPosition;
     [self initBlackCoverView];
     [self initLimitedPlanCoverView];
     [self initLimitedBlackCoverView];
+    [self initPIPPlayerPlaceholderView];
     NSAssert(self, @"super init cannot be nil");
     _isInitialized = false;
     _isPlaying = false;
@@ -790,11 +791,11 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 #if TARGET_OS_IOS
 - (void)pictureInPictureControllerDidStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
     [self disablePictureInPicture];
-    [self hidePIPBackgroundCoverView];
+    [self hidePIPPlayerPlaceholderView];
 }
 
 - (void)pictureInPictureControllerDidStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
-    [self showPIPBackgroundCoverView];
+    [self showPIPPlayerPlaceholderView];
     if (_eventSink != nil) {
         _eventSink(@{@"event" : @"pipStart"});
     }
@@ -879,27 +880,42 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     ]];
 }
 
-- (void) showPIPBackgroundCoverView {
-     if (self._betterPlayerView == nil) {
+- (void) hideLimitedBlackCoverView {
+    if (_limitedBlackCoverView) {
+        [_limitedBlackCoverView removeFromSuperview];
+    }
+}
+
+- (void) initPIPPlayerPlaceholderView {
+    _pipPlayerPlaceholderView = NULL;
+    _pipPlayerPlaceholderView = [[UIView alloc] init];
+    _pipPlayerPlaceholderView.translatesAutoresizingMaskIntoConstraints = false;
+    _pipPlayerPlaceholderView.backgroundColor = [UIColor blackColor];
+}
+
+- (void) showPIPPlayerPlaceholderView {
+    if (self._betterPlayerView == nil) {
         return;
     }
+    UIView *betterPlayerSuperview = self._betterPlayerView.superview;
 
-    _pipBackgroundCoverView = [[UIView alloc] init];
-    _pipBackgroundCoverView.translatesAutoresizingMaskIntoConstraints = false;
-    _pipBackgroundCoverView.backgroundColor = [UIColor blackColor];
-
-    [self._betterPlayerView.superview addSubview:_pipBackgroundCoverView];
-
-    if ([self hasCommonConstraintsBetweenTwoViews:self._betterPlayerView.superview andView2:_pipBackgroundCoverView]) {
+    [betterPlayerSuperview addSubview:_pipPlayerPlaceholderView];
+    if ([self hasCommonConstraintsBetweenTwoViews:betterPlayerSuperview andView2:_pipPlayerPlaceholderView]) {
         return;
     }
 
     [NSLayoutConstraint activateConstraints:@[
-        [_pipBackgroundCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.superview.topAnchor],
-        [_pipBackgroundCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.superview.bottomAnchor],
-        [_pipBackgroundCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.superview.leadingAnchor],
-        [_pipBackgroundCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.superview.trailingAnchor],
+        [_pipPlayerPlaceholderView.topAnchor constraintEqualToAnchor:betterPlayerSuperview.topAnchor],
+        [_pipPlayerPlaceholderView.bottomAnchor constraintEqualToAnchor:betterPlayerSuperview.bottomAnchor],
+        [_pipPlayerPlaceholderView.leadingAnchor constraintEqualToAnchor:betterPlayerSuperview.leadingAnchor],
+        [_pipPlayerPlaceholderView.trailingAnchor constraintEqualToAnchor:betterPlayerSuperview.trailingAnchor],
     ]];
+}
+
+- (void) hidePIPPlayerPlaceholderView {
+    if (_pipPlayerPlaceholderView) {
+        [_pipPlayerPlaceholderView removeFromSuperview];
+    }
 }
 
 - (BOOL)hasCommonConstraintsBetweenTwoViews:(UIView *)view1 andView2:(UIView *)view2 {
@@ -908,18 +924,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }]];
 
     return commonConstraints.count > 0;
-}
-
-- (void) hideLimitedBlackCoverView {
-    if (_limitedBlackCoverView) {
-        [_limitedBlackCoverView removeFromSuperview];
-    }
-}
-
-- (void) hidePIPBackgroundCoverView {
-    if (_pipBackgroundCoverView) {
-        [_pipBackgroundCoverView removeFromSuperview];
-    }
 }
 
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay {

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -44,6 +44,14 @@ int _seekPosition;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
+
+    if (_pipController) {
+        AVPlayerLayer *playerLayer = playerView.playerLayer;
+        if (playerLayer) {
+            _pipController.contentSource = [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:playerLayer];
+        }
+    }
+
     return playerView;
 }
 
@@ -702,7 +710,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
         AVPlayerLayer *playerLayer = self._betterPlayerView.playerLayer;
         if (!_pipController && playerLayer && [AVPictureInPictureController isPictureInPictureSupported]) {
-            _pipController = [[AVPictureInPictureController alloc] initWithPlayerLayer: playerLayer];
+            AVPictureInPictureControllerContentSource *contentSource = [[AVPictureInPictureControllerContentSource alloc] initWithPlayerLayer:playerLayer];
+            _pipController = [[AVPictureInPictureController alloc] initWithContentSource: contentSource];
             if (@available(iOS 14.2, *)) {
                 _pipController.canStartPictureInPictureAutomaticallyFromInline = true;
             }
@@ -745,15 +754,20 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)willStartPictureInPicture: (bool) willStart
 {
     self._willStartPictureInPicture = willStart;
-    _pipController = nil;
-    
+
     if (willStart) {
-        // "0.2 seconds" is a magic number. But it is the same as the library's code. https://github.com/jhomlala/betterplayer/blob/f6a77cf6fbb515f01aa9fb459b2ee739de3e724c/ios/Classes/BetterPlayer.m#L647
-        // It is waiting to release the previous _pipController.
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
-                       dispatch_get_main_queue(), ^{
-            [self setupPipController];
-        });
+        if (_pipController) {
+            _pipController.canStartPictureInPictureAutomaticallyFromInline = true;
+        } else {
+            // "0.2 seconds" is a magic number. But it is the same as the library's code. https://github.com/jhomlala/betterplayer/blob/f6a77cf6fbb515f01aa9fb459b2ee739de3e724c/ios/Classes/BetterPlayer.m#L647
+            // It is waiting to release the previous _pipController.
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                [self setupPipController];
+            });
+        }
+    } else {
+        _pipController.canStartPictureInPictureAutomaticallyFromInline = false;
     }
 }
 
@@ -789,7 +803,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     [self setIsPipMode:false];
     [self hideBlackCoverView];
     [self hideLimitedPlanCoverAfterPipCompletelyGone];
-    
+    _pipController = nil;
+
     bool wasPlaying = _isPlaying;
     if (_eventSink != nil) {
         _eventSink(@{@"event" : @"exitingPIP",

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -389,6 +389,9 @@ bool _isCommandCenterButtonsEnabled = true;
         int64_t textureId = ((NSNumber*)argsMap[@"textureId"]).unsignedIntegerValue;
         BetterPlayer* player = _players[@(textureId)];
         if ([@"setDataSource" isEqualToString:call.method]) {
+            if (!player.isPipMode) {
+                [player resetPipController];
+            }
             [[NSNotificationCenter defaultCenter] removeObserver:self];
             [player clear];
             // This call will clear cached frame because we will return transparent frame


### PR DESCRIPTION
## Description
### Problem

- Due to the change in SDK from iOS 17 and above, there is an issue when initializing PIP.
- When pausing/playing, the code is currently calling the `setupAutomaticPictureInPictureTransition` function, so it leads to the error as in the ticket.

### Solution

- change logic init `_pipController`

### What was done (Please be a little bit specific)
- Implement the solution.
- Test the following cases:
  - Free user: 
    - watch video/live (both free and paid videos) -> pause -> play -> press comment button -> show keyboard -> OK
    -  watch video(both free and paid videos) -> switch to another video -> pause -> play -> press comment button -> show keyboard -> OK
  - Paid user: tested similar cases with free user, and add a few more cases:
      - watch video/live (both free and paid videos) -> go to background -> show PIP -> press go to app button from PIP -> pause -> play -> press comment button -> show keyboard -> OK
    - watch video/live (both free and paid videos) -> go to background -> show PIP -> press go to app button from PIP -> rotate horizontally then vertically (and vice versa case) -> press comment button -> show keyboard -> OK
    -  watch video(both free and paid videos) -> switch to another video -> go to background -> show PIP -> press go to app button from PIP -> pause -> play -> press comment button -> show keyboard -> OK
    -  watch video(both free and paid videos) -> switch to another video -> go to background -> show PIP -> press go to app button from PIP -> rotate horizontally then vertically (and vice versa case) -> press comment button -> show keyboard -> OK
## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5432

## Screenshot or Video (Before/After)
Added later in PR on the dwango-app-ch repo.

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [ ] Builds and runs on Android (No new warnings nor new errors)
