### PR TITLE
DAF-5517: Change logic showLimitedBlackCoverView and showPIPPlayerPlaceholderView

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -856,7 +856,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
-    if (self._betterPlayerView == nil) {
+    if (!self._betterPlayerView.superview) {
         return;
     }
 
@@ -890,7 +890,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showPIPPlayerPlaceholderView {
-    if (self._betterPlayerView == nil) {
+    if (!self._betterPlayerView.superview) {
         return;
     }
     UIView *betterPlayerSuperview = self._betterPlayerView.superview;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -856,7 +856,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showLimitedBlackCoverView {
-    if (!self._betterPlayerView.superview) {
+    if (self._betterPlayerView.superview == nil) {
         return;
     }
 
@@ -890,7 +890,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showPIPPlayerPlaceholderView {
-    if (!self._betterPlayerView.superview) {
+    if (self._betterPlayerView.superview == nil) {
         return;
     }
     UIView *betterPlayerSuperview = self._betterPlayerView.superview;


### PR DESCRIPTION
## Description
### Problem
- In case of opening a new video, the app works normally.
-  In case of opening a video, opening a different paid video, the error occurs. At that time, `_betterPlayerView` has been initialized but `_betterPlayerView.supperview` is null, the `showLimitedBlackCoverView` function is not  `return`  and still adds NSLayoutConstraint.

### Solution

- change logic check return `showLimitedBlackCoverView` function.
- refactor `showPIPPlayerPlaceholderView` function.

### What was done (Please be a little bit specific)
- Implement the solution.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5517

## Screenshot or Video (Before/After)
Added later in PR on the dwango-app-ch repo.

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [ ] Builds and runs on Android (No new warnings nor new errors)
