### PR TITLE
DAF-4374: Fix video frame got leaked while rotating with OFF video image visibility setting

### DIFF
--- a/ios/Classes/BetterPlayer.h
+++ b/ios/Classes/BetterPlayer.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) int overriddenDuration;
 @property(nonatomic) AVPlayerTimeControlStatus lastAvPlayerTimeControlStatus;
 @property(nonatomic) UIView* blackCoverView;
+@property(nonatomic) UIView* playerCoverView;
 @property(nonatomic) UIImageView* limitedPlanCoverView;
 @property(nonatomic) UIView* limitedBlackCoverView;
 @property(nonatomic) UIView* pipPlayerPlaceholderView;
@@ -72,6 +73,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setIsPremiumBannerDisplay:(BOOL) isDisplay;
 - (void)showBlackCoverViewInPIP;
 - (void)hideBlackCoverView;
+- (void)showPlayerCoverView;
+- (void)hidePlayerCoverView;
 - (void)showLimitedPlanCoverViewInPIP;
 - (void)hideLimitedPlanCoverViewInPIP;
 - (void)showLimitedBlackCoverView;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -46,6 +46,9 @@ int _seekPosition;
     BetterPlayerView *playerView = [[BetterPlayerView alloc] initWithFrame:CGRectZero];
     playerView.player = _player;
     self._betterPlayerView = playerView;
+    if (_eventSink) {
+        _eventSink(@{@"event" : @"platformViewCreated"});
+    }
     return playerView;
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -24,6 +24,7 @@ int _seekPosition;
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super init];
     [self initBlackCoverView];
+    [self initPlayerCoverView];
     [self initLimitedPlanCoverView];
     [self initLimitedBlackCoverView];
     [self initPIPPlayerPlaceholderView];
@@ -1015,6 +1016,38 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void) hideBlackCoverView {
     if (_blackCoverView) {
         [_blackCoverView removeFromSuperview];
+    }
+}
+
+- (void) initPlayerCoverView {
+    _playerCoverView = NULL;
+    _playerCoverView = [[UIView alloc] init];
+    _playerCoverView.translatesAutoresizingMaskIntoConstraints = false;
+    _playerCoverView.backgroundColor = [UIColor blackColor];
+}
+
+- (void) showPlayerCoverView {
+    if (self._betterPlayerView == nil) {
+        return;
+    }
+
+    [self._betterPlayerView addSubview:_playerCoverView];
+    
+    if ([self hasCommonConstraintsBetweenTwoViews:self._betterPlayerView andView2:_playerCoverView]) {
+        return;
+    }
+
+    [NSLayoutConstraint activateConstraints:@[
+        [_playerCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
+        [_playerCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
+        [_playerCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
+        [_playerCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
+    ]];
+}
+
+- (void) hidePlayerCoverView {
+    if (_playerCoverView) {
+        [_playerCoverView removeFromSuperview];
     }
 }
 

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -615,16 +615,11 @@ bool _isCommandCenterButtonsEnabled = true;
                 [player setIsPremiumBannerDisplay:isDisplay];
             }
         } else if ([@"setIsPlayerVideoVisible" isEqualToString:call.method]){
-            NSLog(@"BpPlugin.setIsPlayerVideoVisible:");
-
             BOOL isVisible = false;
             id isVisibleObject = [argsMap objectForKey:@"isVisible"];
             
             if (isVisibleObject != [NSNull null]) {
                 isVisible = [[argsMap objectForKey:@"isVisible"] boolValue];
-                
-                NSLog(@"%@", isVisible ? @"true" : @"false");
-
                 
                 if (isVisible) {
                     [player hidePlayerCoverView];

--- a/ios/Classes/BetterPlayerPlugin.m
+++ b/ios/Classes/BetterPlayerPlugin.m
@@ -614,6 +614,24 @@ bool _isCommandCenterButtonsEnabled = true;
 
                 [player setIsPremiumBannerDisplay:isDisplay];
             }
+        } else if ([@"setIsPlayerVideoVisible" isEqualToString:call.method]){
+            NSLog(@"BpPlugin.setIsPlayerVideoVisible:");
+
+            BOOL isVisible = false;
+            id isVisibleObject = [argsMap objectForKey:@"isVisible"];
+            
+            if (isVisibleObject != [NSNull null]) {
+                isVisible = [[argsMap objectForKey:@"isVisible"] boolValue];
+                
+                NSLog(@"%@", isVisible ? @"true" : @"false");
+
+                
+                if (isVisible) {
+                    [player hidePlayerCoverView];
+                } else {
+                    [player showPlayerCoverView];
+                }
+            }
         } else {
             result(FlutterMethodNotImplemented);
         }

--- a/lib/src/configuration/better_player_event_type.dart
+++ b/lib/src/configuration/better_player_event_type.dart
@@ -1,6 +1,7 @@
 ///Supported event types
 enum BetterPlayerEventType {
   initialized,
+  platformViewCreated,
   play,
   pause,
   seekTo,

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1168,6 +1168,11 @@ class BetterPlayerController {
   ///Handle VideoEvent when remote controls notification / PiP is shown
   void _handleVideoEvent(VideoEvent event) async {
     switch (event.eventType) {
+      case VideoEventType.platformViewCreated:
+        _postEvent(
+          BetterPlayerEvent(BetterPlayerEventType.platformViewCreated),
+        );
+        break;
       case VideoEventType.play:
         _postEvent(BetterPlayerEvent(BetterPlayerEventType.play));
         break;

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -1294,6 +1294,10 @@ class BetterPlayerController {
     videoPlayerController!.setIsPremiumBannerDisplay(isDisplay);
   }
 
+  void setIsPlayerVideoVisible(bool isVisible) {
+    videoPlayerController!.setIsPlayerVideoVisible(isVisible);
+  }
+
   void setDuration(Duration duration) {
     if (videoPlayerController != null) {
       videoPlayerController!.setDuration(duration);

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -524,6 +524,17 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
     );
   }
 
+  @override
+  Future<void> setIsPlayerVideoVisible(int? textureId, bool isVisible) {
+    return _channel.invokeMethod<void>(
+      'setIsPlayerVideoVisible',
+      <String, dynamic>{
+        'textureId': textureId,
+        'isVisible': isVisible,
+      },
+    );
+  }
+
   EventChannel _eventChannelFor(int? textureId) {
     return EventChannel('better_player_channel/videoEvents$textureId');
   }

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -391,6 +391,11 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
             duration: Duration(milliseconds: map['duration'] as int),
             size: size,
           );
+        case 'platformViewCreated':
+          return VideoEvent(
+            eventType: VideoEventType.platformViewCreated,
+            key: key,
+          );
         case 'completed':
           return VideoEvent(
             eventType: VideoEventType.completed,

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -675,6 +675,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     _videoPlayerPlatform.setIsPremiumBannerDisplay(_textureId, isDisplay);
   }
 
+  void setIsPlayerVideoVisible(bool isVisible) {
+    debugPrint('VPC.setIsPlayerVideoVisible: $isVisible');
+    _videoPlayerPlatform.setIsPlayerVideoVisible(_textureId, isVisible);
+  }
+
   static Future clearCache() async {
     return _videoPlayerPlatform.clearCache();
   }

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -222,6 +222,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           _initializingCompleter.complete(null);
           _applyPlayPause();
           break;
+        case VideoEventType.platformViewCreated:
+          break;
         case VideoEventType.completed:
           value = value.copyWith(isPlaying: false, position: value.duration);
           _timer?.cancel();

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -678,7 +678,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   void setIsPlayerVideoVisible(bool isVisible) {
-    debugPrint('VPC.setIsPlayerVideoVisible: $isVisible');
     _videoPlayerPlatform.setIsPlayerVideoVisible(_textureId, isVisible);
   }
 

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -473,6 +473,9 @@ enum VideoEventType {
   /// The video has been initialized.
   initialized,
 
+  /// The platform view has been created.
+  platformViewCreated,
+
   /// The playback has ended.
   completed,
 

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -191,6 +191,11 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('setIsPremiumBannerDisplay() has not been implemented.');
   }
 
+  Future<void> setIsPlayerVideoVisible(int? textureId, bool isVisible) {
+    throw UnimplementedError(
+        'setIsPlayerVideoVisible() has not been implemented.');
+  }
+
   /// Returns a widget displaying the video with a given textureID.
   Widget buildView(int? textureId) {
     throw UnimplementedError('buildView() has not been implemented.');


### PR DESCRIPTION
## Description

### Problem
- The video frame got leaked while rotating with OFF video image visibility setting.
- The iOS Platform view doesn't sync with the Flutter layout, therefore we can't fix it on the flutter side.
- After the fix, when switching to another video, the platform view is recreated after adding a player cover view => There is nothing to cover the player again. => still bug.

### Solution
### What was done (Please be a little bit specific)

- Add a cover view on the platform side.
- Add `platformViewCreated` event.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-4374

## Screenshot or Video (Before/After)
(For a new design, a screenshot should be required. But for new functionality, a video is a great help.)

- uploaded in main PR: https://github.com/dwango-nfc/dwango-app-ch/pull/2431

