### PR TITLE
DAF-5561: Change playback speed logic for iOS Simulator

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -637,8 +637,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)setSpeed:(double)speed result:(FlutterResult)result {
     _playerRate = speed;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (_isPlaying){
-            _player.rate = _playerRate;
+        if (self->_isPlaying){
+            self->_player.rate = self->_playerRate;
         }
     });
     result(nil);

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -636,12 +636,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setSpeed:(double)speed result:(FlutterResult)result {
     _playerRate = speed;
-    if (_isPlaying){
-        _player.rate = _playerRate;
-    }
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (_isPlaying){
+            _player.rate = _playerRate;
+        }
+    });
     result(nil);
 }
-
 
 - (void)setTrackParameters:(int) width: (int) height: (int)bitrate {
     _player.currentItem.preferredPeakBitRate = bitrate;

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -644,6 +644,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setManualSpeed:(double)speed {
 #if TARGET_OS_SIMULATOR
+    // This is a workaround
+    // In the simulator, if setSpeed is not equal to 1, seeking the player will cause the player to freeze.
     _player.rate = 1;
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),


### PR DESCRIPTION
## Description
### Problem
- In the simulator, if setSpeed is not equal to 1, seeking the player will cause the player to freeze.

### Solution
- Workaround for the setSpeed function. 
- Apply to all instances where the rate is set in the code.

### What was done (Please be a little bit specific)
- Workaround for the setSpeed function.
- Apply to all instances where the rate is set in the code.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5561

## Screenshot or Video (Before/After)
Added later in PR on the dwango-app-ch repo.

## Ready for review checklist
Basically, you must check all. (When you ignore any checks, please write each reason.)

- [x] All sections above are properly filled in
- [x] The PR only deals with one functionality/bug
- [ ] Includes code refactoring? If yes, the following sub checks are required.
    - [ ] The changes were tested. So there is no degradation.
    - [ ] The change is not too big. (Reviewers can review it.)
- [ ] Includes change of spec? If yes, the sub check is required.
    - [ ] Updated the document.
- [x] Builds and runs on iOS (No new warnings nor new errors)
- [ ] Builds and runs on Android (No new warnings nor new errors)
