### PR TITLE
DAF-5581: Fix still display video frame in iOS PIP while off video display setting

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -1097,13 +1097,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
 }
 
-/// Check when the PIP is completely gone.
+/// Do action after the PIP is completely gone.
 ///
 /// - if _isPipMode == true and isPictureInPictureActive is whatever (still in PIP mode)
 ///     - All the check is false, finish this function without any actions.
 ///     - The pictureInPictureControllerWillStartPictureInPicture logics already handled when re-entering PIP and while in PIP mode.
 /// - if _isPipMode == false and isPictureInPictureActive == true (while exiting PIP, and not completed yet)
-///     - Call the loop and re-checking after 0.1 seconds.
+///     - Call the loop and re-checking after 0.05 seconds.
 /// - if _isPipMode == false and isPictureInPictureActive == false (the PIP is completely gone)
 ///     - Do callback actions.
 - (void)checkWhenPipCompletelyGoneAndDoAction: (void (^)(void))action {

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -21,6 +21,8 @@ int _seekPosition;
 #endif
 
 @implementation BetterPlayer
+bool _isPlayerCoverDisplaying = false;
+
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super init];
     [self initBlackCoverView];
@@ -781,7 +783,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)pictureInPictureControllerWillStopPictureInPicture:(AVPictureInPictureController *)pictureInPictureController  API_AVAILABLE(ios(9.0)){
     [self setIsPipMode:false];
     [self hideBlackCoverView];
-    [self hideLimitedPlanCoverAfterPipCompletelyGone];
+    [self checkWhenPipCompletelyGoneAndDoAction: ^() {
+        [self hideLimitedPlanCoverViewInPIP];
+        if (_isPlayerCoverDisplaying) {
+            // This method will move _playerCoverView from UIWindow to _betterPlayerView.superview.
+            [self showPlayerCoverView];
+        }
+    }];
 
     bool wasPlaying = _isPlaying;
     if (_eventSink != nil) {
@@ -799,6 +807,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         [self showLimitedPlanCoverViewInPIP];
     } else {
         [self hideLimitedPlanCoverViewInPIP];
+    }
+    if (_isPlayerCoverDisplaying) {
+        [self showPlayerCoverViewInPIP];
     }
     
     // When change to PIP mode, need to correct control status
@@ -1009,28 +1020,48 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void) showPlayerCoverView {
-    if (self._betterPlayerView == nil) {
+    UIView *betterPlayerSuperview = self._betterPlayerView.superview;
+    if (betterPlayerSuperview == nil) {
         return;
     }
 
-    [self._betterPlayerView addSubview:_playerCoverView];
+    [betterPlayerSuperview addSubview:_playerCoverView];
     
-    if ([self hasCommonConstraintsBetweenTwoViews:self._betterPlayerView andView2:_playerCoverView]) {
+    if ([self hasCommonConstraintsBetweenTwoViews:betterPlayerSuperview andView2:_playerCoverView]) {
         return;
     }
 
     [NSLayoutConstraint activateConstraints:@[
-        [_playerCoverView.topAnchor constraintEqualToAnchor:self._betterPlayerView.topAnchor],
-        [_playerCoverView.bottomAnchor constraintEqualToAnchor:self._betterPlayerView.bottomAnchor],
-        [_playerCoverView.leadingAnchor constraintEqualToAnchor:self._betterPlayerView.leadingAnchor],
-        [_playerCoverView.trailingAnchor constraintEqualToAnchor:self._betterPlayerView.trailingAnchor],
+        [_playerCoverView.topAnchor constraintEqualToAnchor:betterPlayerSuperview.topAnchor],
+        [_playerCoverView.bottomAnchor constraintEqualToAnchor:betterPlayerSuperview.bottomAnchor],
+        [_playerCoverView.leadingAnchor constraintEqualToAnchor:betterPlayerSuperview.leadingAnchor],
+        [_playerCoverView.trailingAnchor constraintEqualToAnchor:betterPlayerSuperview.trailingAnchor],
     ]];
+    _isPlayerCoverDisplaying = true;
 }
+
+/// This method will move _playerCoverView from _betterPlayerView.superview to UIWindow.
+- (void) showPlayerCoverViewInPIP {
+    UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
+    if (window && _isPipMode) {
+        [window addSubview:_playerCoverView];
+        
+        if ([self hasCommonConstraintsBetweenTwoViews:window andView2:_playerCoverView]) {
+            return;
+        }
+        [NSLayoutConstraint activateConstraints:@[
+            [_playerCoverView.topAnchor constraintEqualToAnchor:window.topAnchor],
+            [_playerCoverView.bottomAnchor constraintEqualToAnchor:window.bottomAnchor],
+            [_playerCoverView.leadingAnchor constraintEqualToAnchor:window.leadingAnchor],
+            [_playerCoverView.trailingAnchor constraintEqualToAnchor:window.trailingAnchor],
+        ]];
+    }}
 
 - (void) hidePlayerCoverView {
     if (_playerCoverView) {
         [_playerCoverView removeFromSuperview];
     }
+    _isPlayerCoverDisplaying = false;
 }
 
 - (void) initLimitedPlanCoverView {
@@ -1066,26 +1097,26 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
 }
 
-/// Hide LimitedPlanCoverView after the PIP is completely gone.
+/// Check when the PIP is completely gone.
 ///
 /// - if _isPipMode == true and isPictureInPictureActive is whatever (still in PIP mode)
 ///     - All the check is false, finish this function without any actions.
-///     - The showLimitedPlanCoverView logics already handled when re-entering PIP and while in PIP mode.
+///     - The pictureInPictureControllerWillStartPictureInPicture logics already handled when re-entering PIP and while in PIP mode.
 /// - if _isPipMode == false and isPictureInPictureActive == true (while exiting PIP, and not completed yet)
 ///     - Call the loop and re-checking after 0.1 seconds.
 /// - if _isPipMode == false and isPictureInPictureActive == false (the PIP is completely gone)
-///     - Hide LimitedPlanCoverView.
-- (void)hideLimitedPlanCoverAfterPipCompletelyGone {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+///     - Do callback actions.
+- (void)checkWhenPipCompletelyGoneAndDoAction: (void (^)(void))action {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (_isPipMode) {
             return;
         }
         if ([_pipController isPictureInPictureActive]) {
-            [self hideLimitedPlanCoverAfterPipCompletelyGone];
+            [self checkWhenPipCompletelyGoneAndDoAction:action];
             return;
         }
         
-        [self hideLimitedPlanCoverViewInPIP];
+        action();
     });
 }
 

--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -803,13 +803,13 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 - (void)pictureInPictureControllerWillStartPictureInPicture:(AVPictureInPictureController *)pictureInPictureController {
     [self setIsPipMode:true];
 
+    if (_isPlayerCoverDisplaying) {
+        [self showPlayerCoverViewInPIP];
+    }
     if (_isPremiumBannerDisplay) {
         [self showLimitedPlanCoverViewInPIP];
     } else {
         [self hideLimitedPlanCoverViewInPIP];
-    }
-    if (_isPlayerCoverDisplaying) {
-        [self showPlayerCoverViewInPIP];
     }
     
     // When change to PIP mode, need to correct control status


### PR DESCRIPTION
## Description
### Problem
- The video frames hiding feature hasn't been implemented in the iOS PIP.
- The video frames were leaked while rotating after returning from iOS PIP although already off the video display setting.
 The reason is that when entering PIP, the iOS only left the Player's layer, so when exiting PIP, no cover view is attached to the Player anymore.
 
### Solution
### What was done (Please be a little bit specific)
- Add the `PlayerCoverView` to the PIP `window` when entering PIP.
- Move the `PlayerCoverView` from the PIP `window` back to the `_betterPlayerView.superview` when exiting PIP.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5581

## Screenshot or Video (Before/After)

- uploaded in main PR: https://github.com/dwango-nfc/dwango-app-ch/pull/2472

