### PR TITLE
DAF-5708: Prevent Android app crash when playing video after a short time

### DIFF
--- a/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
+++ b/android/src/main/kotlin/com/jhomlala/better_player/BetterPlayer.kt
@@ -97,6 +97,7 @@ internal class BetterPlayer(
         )
         loadControl = loadBuilder.build()
         exoPlayer = ExoPlayer.Builder(context)
+            .setRenderersFactory(DefaultRenderersFactory(context).setEnableDecoderFallback(true))
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
             .build()


### PR DESCRIPTION
## Description
### Problem
- Android app crashes when playing video after a short time (on Xperia VI phone)
 
### Solution
### What was done (Please be a little bit specific)
- Set flag `setEnableDecoderFallback(true)` for Exoplayer
 - In case hardware decoder has error, auto using software decoder (ref: https://developer.android.com/reference/kotlin/androidx/media3/transformer/DefaultDecoderFactory.Builder#setEnableDecoderFallback(boolean))
> Sets whether the decoder can fallback.
>
>This decides whether to enable fallback to lower-priority decoders if decoder initialization fails. This may result in using a decoder that is less efficient or slower than the primary decoder.
>
>The default value is false.

## Reference
### JIRA
https://dw-ml-nfc.atlassian.net/browse/DAF-5708

### Testing
Tested on these devices and don't see the different before and after this fix
 - Pixel 3a
 - Pixel 8

